### PR TITLE
일반 사용자 FE/BE 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,11 +48,12 @@
     "element-plus": "^2.2.13",
     "url-loader": "^4.1.1",
     "vue": "^3.2.37",
+    "vue-cookies": "^1.8.1",
     "vue-file-loader": "0.0.1",
     "vue-router": "^4.0.16",
     "vue3-datepicker": "^0.3.4",
     "vuetify": "^2.6.9",
     "vuex": "^4.0.2",
-    "vue-cookies": "^1.8.1"
+    "vuex-persistedstate": "^4.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "vue-router": "^4.0.16",
     "vue3-datepicker": "^0.3.4",
     "vuetify": "^2.6.9",
-    "vuex": "^4.0.2"
+    "vuex": "^4.0.2",
+    "vue-cookies": "^1.8.1"
   }
 }

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,0 +1,36 @@
+import service from "./service"
+import { API } from "./config"
+
+export const api = {
+    signIn(loginData) {
+        console.log('api signIn')
+        return service.post(`${API.signIn}`, loginData)
+    },
+
+    signUp(params) {
+      console.log('api signUp')
+      return service.post(`${API.signUp}`, params)
+    },
+
+    getDevices(params, accessToken) {
+      console.log('api getDevices accessToken', accessToken)
+      return service.get(`${API.getDevices}`, { 
+        // headers: {
+        //   Authorization: 'Bearer ' + accessToken //the token is a variable which holds the token
+        // },
+        params: params
+      })
+    },
+
+    // TODO 2022-11-03
+    requestEquipmentRental(params, accessToken) {
+      console.log('api requestEquipmentRental params', params)
+      console.log('api requestEquipmentRental accessToken', accessToken)
+      console.log('api requestEquipmentRental params.userId', params.userId)
+      return service.post(`${API.requestEquipmentRental(params.userId)}`, params, { 
+        // headers: {
+        //   Authorization: 'Bearer ' + accessToken //the token is a variable which holds the token
+        // }
+      })
+    }
+}

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -12,8 +12,8 @@ export const api = {
       return service.post(`${API.signUp}`, params)
     },
 
-    getDevices(params, accessToken) {
-      console.log('api getDevices accessToken', accessToken)
+    getDevices(params) {
+      console.log('api getDevices')
       return service.get(`${API.getDevices}`, { 
         // headers: {
         //   Authorization: 'Bearer ' + accessToken //the token is a variable which holds the token
@@ -23,14 +23,23 @@ export const api = {
     },
 
     // TODO 2022-11-03
-    requestEquipmentRental(params, accessToken) {
+    requestEquipmentRental(params) {
       console.log('api requestEquipmentRental params', params)
-      console.log('api requestEquipmentRental accessToken', accessToken)
       console.log('api requestEquipmentRental params.userId', params.userId)
       return service.post(`${API.requestEquipmentRental(params.userId)}`, params, { 
         // headers: {
         //   Authorization: 'Bearer ' + accessToken //the token is a variable which holds the token
         // }
+      })
+    },
+
+    getRentalHistory(params) {
+      console.log('getRentalHistory', params)
+      return service.get(`${API.getRentalHistory(params.userId)}`, { 
+        // headers: {
+        //   Authorization: 'Bearer ' + accessToken //the token is a variable which holds the token
+        // }
+        params: params
       })
     }
 }

--- a/src/api/config.js
+++ b/src/api/config.js
@@ -1,6 +1,3 @@
-// export const API_URL = process.env.BASE_URL
-export const API_URL = 'http://localhost:9090/'
-
 // api list structure
 export const API = {
     // 일반사용자 > 로그인 (JWT 토큰 발급)
@@ -14,4 +11,7 @@ export const API = {
 
     // 일반사용자 > 대시보드 > 메인 > 기본 : 대여 신청하기
     requestEquipmentRental: (userId) => `dashboard/general-user/users/${userId}/rentals/request`,
+
+    // 일반사용자 > 대시보드 > 앱바 > 내 정보 : 신청 내역 조회
+    getRentalHistory: (userId) => `dashboard/general-user/users/${userId}/rentals/history`,
 }

--- a/src/api/config.js
+++ b/src/api/config.js
@@ -1,0 +1,17 @@
+// export const API_URL = process.env.BASE_URL
+export const API_URL = 'http://localhost:9090/'
+
+// api list structure
+export const API = {
+    // 일반사용자 > 로그인 (JWT 토큰 발급)
+    signIn: 'auth/login',
+
+    // 일반사용자 > 계정등록
+    signUp: 'auth/register',
+  
+    // 일반사용자 > 대시보드 > 메인 > 기본 : 장비 목록 조회
+    getDevices: 'dashboard/general-user/devices',
+
+    // 일반사용자 > 대시보드 > 메인 > 기본 : 대여 신청하기
+    requestEquipmentRental: (userId) => `dashboard/general-user/users/${userId}/rentals/request`,
+}

--- a/src/api/service.js
+++ b/src/api/service.js
@@ -1,9 +1,10 @@
 import axios from 'axios'
-import VueCookies from 'vue-cookies'
+// import VueCookies from 'vue-cookies'
 
 // 프로젝트 설정에 맞게, 기본적인 정보를 넣어주세요
 const service = axios.create({
-  baseURL: 'http://localhost:9090/',
+  baseURL: 'http://localhost:9090/', // local
+  // baseURL: 'https://cc637a0d-ed0c-4cc6-a1b7-e421613ec154.mock.pstmn.io/', // mockup
   timeout: '10000',
   withCredentials: false
 })
@@ -20,7 +21,11 @@ service.interceptors.request.use((config) => {
 
     console.log('service.interceptors.request config', config)
 
-    const accessToken = VueCookies.get('accessToken')
+    // const accessToken = VueCookies.get('accessToken')
+    const accessToken = localStorage.getItem('access_token')
+
+    console.log('axios request accessToken', accessToken)
+
     if (accessToken) {
       config.headers.Authorization = `Bearer ${accessToken}`
     }
@@ -34,31 +39,35 @@ service.interceptors.request.use((config) => {
 
 // 응답에 필요한 처리를 넣어주세요.
 service.interceptors.response.use(function(config) {
-    console.log('----- service.interceptors.response');
-    console.log('----- config', config);
-    console.log('----- service.interceptors.response');
-  
-    // if u add new Chainable promise or other interceptor
-    // You have to return `config` inside of a rquest
-    // otherwise u will get a very confusing error
-    // and spend sometime to debug it.
-    return config;
-  }, function(error) {
-    return Promise.reject(error);
-  })
+  // 요청을 보내기 전에 수행할 일
+  console.log('----- service.interceptors.response');
+  console.log('----- config', config);
+  console.log('----- service.interceptors.response');
 
-function printError(e) {
-    console.log(e)
-}
+  // if u add new Chainable promise or other interceptor
+  // You have to return `config` inside of a rquest
+  // otherwise u will get a very confusing error
+  // and spend sometime to debug it.
+  return config;
+}, function(error) {
+  // 오류 요청을 보내기전 수행할 일
+  return Promise.reject(error);
+})
 
 // 각 메소드별 함수를 생성해 주세요.
 export default {
   async get(...options) {
     try {
       const res = await service.get(...options)
-      return res
+      console.log('async get', res)
+
+      console.log('async get res.code', res.code)
+      console.log('async get res.data', res.data)
+
+      return res.data
     } catch (e) {
-      return printError(e)
+      console.log('async get', e)
+      return e.response.data
     }
   },
 
@@ -66,9 +75,11 @@ export default {
     // 공통
     try {
         const res = await service.post(...options)
-        return res
+        console.log('async post', res)
+        return res.data
     } catch (e) {
-        return printError(e)
+        console.log('async post', e)
+        return e.response.data
     }
   },
 
@@ -76,9 +87,11 @@ export default {
     // 공통
     try {
         const res = await service.put(...options)
-        return res
+        console.log('async put', res)
+        return res.data
     } catch (e) {
-        return printError(e)
+        console.log('async put', e)
+        return e.response.data
     }
   },
 
@@ -86,9 +99,11 @@ export default {
     // 공통
     try {
         const res = await service.delete(...options)
-        return res
+        console.log('async delete', res)
+        return res.data
     } catch (e) {
-        return printError(e)
+        console.log('async delete', e)
+        return e.response.data
     }
   },
 }

--- a/src/api/service.js
+++ b/src/api/service.js
@@ -1,0 +1,94 @@
+import axios from 'axios'
+import VueCookies from 'vue-cookies'
+
+// 프로젝트 설정에 맞게, 기본적인 정보를 넣어주세요
+const service = axios.create({
+  baseURL: 'http://localhost:9090/',
+  timeout: '10000',
+  withCredentials: false
+})
+  
+// axios 요청 시 필요한 정보를 넣어주세요
+service.interceptors.request.use((config) => {
+    // config.headers = {}
+    // const CancelToken = axios.CancelToken;
+    // return {
+    //     ...config,
+    //     cancelToken: new CancelToken((cancel) => cancel('Cancel repeated request'))
+    //   }
+    // }
+
+    console.log('service.interceptors.request config', config)
+
+    const accessToken = VueCookies.get('accessToken')
+    if (accessToken) {
+      config.headers.Authorization = `Bearer ${accessToken}`
+    }
+
+      // if (localStorage.getItem('profile')) {
+      //     config.headers.Authorization = `Bearer ${JSON.parse(localStorage.getItem('profile')).token}`;
+      // }
+    return config
+  }
+)
+
+// 응답에 필요한 처리를 넣어주세요.
+service.interceptors.response.use(function(config) {
+    console.log('----- service.interceptors.response');
+    console.log('----- config', config);
+    console.log('----- service.interceptors.response');
+  
+    // if u add new Chainable promise or other interceptor
+    // You have to return `config` inside of a rquest
+    // otherwise u will get a very confusing error
+    // and spend sometime to debug it.
+    return config;
+  }, function(error) {
+    return Promise.reject(error);
+  })
+
+function printError(e) {
+    console.log(e)
+}
+
+// 각 메소드별 함수를 생성해 주세요.
+export default {
+  async get(...options) {
+    try {
+      const res = await service.get(...options)
+      return res
+    } catch (e) {
+      return printError(e)
+    }
+  },
+
+  async post(...options) {
+    // 공통
+    try {
+        const res = await service.post(...options)
+        return res
+    } catch (e) {
+        return printError(e)
+    }
+  },
+
+  async put(...options) {
+    // 공통
+    try {
+        const res = await service.put(...options)
+        return res
+    } catch (e) {
+        return printError(e)
+    }
+  },
+
+  async delete(...options) {
+    // 공통
+    try {
+        const res = await service.delete(...options)
+        return res
+    } catch (e) {
+        return printError(e)
+    }
+  },
+}

--- a/src/common/common.js
+++ b/src/common/common.js
@@ -1,0 +1,42 @@
+const methods = {
+    console_log(str) {
+        console.log('[common.js]', str)
+    },
+
+    /**
+     * Decode JWT (without using a library)
+     *
+     * @param {String} token 인코딩된 JWT 토큰
+     * @returns 디코딩된 객체
+     */
+    parseJwt (token) {
+        console.log('[common.js][parseJwt]', token)
+        var base64Url = token.split('.')[1]
+        var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+        var jsonPayload = decodeURIComponent(window.atob(base64).split('').map(function(c) {
+            return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+        }).join(''))
+
+        return JSON.parse(jsonPayload)
+    },
+
+    /**
+     * Gets Date Formatted As yyyy-MM-dd
+     *
+     * @param {Date} date Date 형식 날짜값
+     * @returns yyyy-MM-dd
+     */
+    formatDate(date) {
+        console.log('[common.js][formatDate]', date)
+        const tzOffset = date.getTimezoneOffset() * 60 * 1000
+        return new Date(date - tzOffset).toISOString().split('T')[0]
+    }
+}
+
+export default {
+    install(Vue) {
+        Vue.config.globalProperties.$log = methods.console_log
+        Vue.config.globalProperties.$parseJwt = methods.parseJwt
+        Vue.config.globalProperties.$formatDate = methods.formatDate
+    }
+}

--- a/src/components/apply/ApplyCardList.vue
+++ b/src/components/apply/ApplyCardList.vue
@@ -1,16 +1,27 @@
 <template>
   <div class="inner">
     <div class="list-card apply">
-      <CardItem v-for="equipment in applyList" :key="equipment" :equipment="equipment" @click="linkPrevent($event)" @showModal="showModal=true"/>
+      <CardItem
+        v-for="equipment in applyList"
+        :key="equipment" 
+        :equipment="equipment" 
+        @click="handlePreventEvent($event)" 
+        @showModal="handleShowModal(equipment)" />
     </div>
   </div>
-
-  <CancelModal v-if="showModal" class="detail-info" @closeModal="showModal = false" />
+  <CancelModal
+    v-if="showModal"
+    class="detail-info" 
+    :equipment-info="equipmentInfo" 
+    @deleteEquipment="handleDeleteEquipment"
+    @closeModal="handleCloseModal" />
 </template>
 
 <script>
 import CardItem from '~/components/basic/CardItem'
 import CancelModal from '~/components/modal/CancelModal'
+
+import { mapState } from 'vuex'
 
 export default {
   components:{
@@ -19,15 +30,85 @@ export default {
   },
   data(){
     return {
-      showModal : false
+      showModal : false,
+      equipmentInfo: {}
     }
   },
+  computed: {
+    ...mapState('equipments', [
+        'countApplyItem',
+        'applyList'
+      ])
+  },
   props:{
-    applyList:Array
+    // 대여 신청할 기기목록
+    applyList: {
+      type: Array,
+      default: () => []
+    }
   },
   methods:{
     linkPrevent(e){
       e.preventDefault();
+    },
+
+        /**
+     * 대여 신청할 기기목록의 CardItem 영역 중 X 버튼 외 영역 클릭 시 이벤트 방지
+     *
+     * @param {Event} e 이벤트 객체
+     */
+     handlePreventEvent(e) {
+      e.preventDefault()
+    },
+
+    /**
+     * <해당 기기를 신청 목록에서 삭제하시겠습니까?> 모달 열기
+     *
+     * @param {Object} selectedItem 대여 신청할 기기목록 중 신청 목록에서 삭제할 기기
+     */
+    handleShowModal(selectedItem) {
+      this.equipmentInfo = selectedItem
+      this.modalShow()
+      console.log('ApplyCardList.vue handleShowModal', selectedItem)
+    },
+
+    handleCloseModal() {
+      this.modalHide()
+      console.log('ApplyCardList.vue handleCloseModal')
+    },
+
+    /**
+     * <해당 기기를 신청 목록에서 삭제하시겠습니까?> 모달 내부 삭제 버튼 액션 수행
+     *
+     * @param {Object} selectedItem 대여 신청할 기기목록 중 신청 목록에서 삭제할 기기
+     */
+    handleDeleteEquipment(selectedItem) {
+
+      console.log('ApplyCardList.vue handleDeleteEquipment', selectedItem)
+
+      const index = this.applyList.findIndex(equipment => equipment.id === selectedItem.id)
+      this.applyList.splice(index, 1)
+      this.$store.commit('equipments/updateState', {
+        applyList : this.applyList,
+        countApplyItem : this.applyList.length
+      })
+
+      this.modalHide()
+
+      this.$emit('deleteEquipment', selectedItem) // Collapse.vue (Parent Component)
+      if (this.applyList.length == 0) {
+        this.$emit('triggerCollapse') // Collapse.vue (Parent Component)
+      }
+    },
+
+    // 모달 열기 플래그 값 업데이트
+    modalShow() {
+      this.showModal = true
+    },
+
+    // 모달 닫기 플래그 값 업데이트
+    modalHide() {
+      this.showModal = false
     }
   }
 }

--- a/src/components/basic/BasicTab.vue
+++ b/src/components/basic/BasicTab.vue
@@ -1,7 +1,10 @@
 <template>
     <div>
-        <input type="radio" class="btn-check" :name="name" :id="tab.id" autocomplete="off">
-        <label class="btn tab" :for="tab.id"><slot></slot></label>
+        <button type="button" class="tab">
+            <slot></slot>
+        </button>
+        <!-- <input type="radio" class="btn-check" :name="name" :id="tab.id" autocomplete="off"> -->
+        <!-- <label class="btn tab" :for="tab.id"><slot></slot></label> -->
     </div>
 </template>
 
@@ -11,9 +14,9 @@ export default {
         tab:{
             type:Object,
             default(){
-                return{
+                return {
                     text:"전체",
-                    id:"option1",
+                    id:"all",
                     isActive:"false"
                 }
             }
@@ -27,10 +30,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.btn.tab{font-size:14px;color:$M-gray4;padding:8px 12px;border:none;background:none;border-radius:4px;line-height:18px;}
-.btn-check:checked + .btn.tab{background-color:$M-gray2;color:$M-black;}
-.active{
-    .btn.tab{background-color:$M-gray2;color:$M-black;}
-}
+// .btn.tab{font-size:14px;color:$M-gray4;padding:8px 12px;border:none;background:none;border-radius:4px;line-height:18px;}
+// .btn-check:checked + .btn.tab{background-color:$M-gray2;color:$M-black;}
+// .active{
+//     .btn.tab{background-color:$M-gray2;color:$M-black;}
+// }
 
+button.tab{font-size:14px;color:$M-gray4;padding:8px 12px;margin-right:4px;border:none;background:none;border-radius:4px;line-height:18px;
+    &.active{background-color:$M-gray2;color:$M-black;}
+    &:last-child{margin-right:0;}
+}
 </style>

--- a/src/components/basic/BasicTab.vue
+++ b/src/components/basic/BasicTab.vue
@@ -1,10 +1,10 @@
 <template>
     <div>
-        <button type="button" class="tab">
+        <!-- <button type="button" class="tab">
             <slot></slot>
-        </button>
-        <!-- <input type="radio" class="btn-check" :name="name" :id="tab.id" autocomplete="off"> -->
-        <!-- <label class="btn tab" :for="tab.id"><slot></slot></label> -->
+        </button> -->
+        <input type="radio" class="btn-check" :name="name" :id="tab.id" autocomplete="off">
+        <label class="btn tab" :for="tab.id"><slot></slot></label>
     </div>
 </template>
 
@@ -30,14 +30,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-// .btn.tab{font-size:14px;color:$M-gray4;padding:8px 12px;border:none;background:none;border-radius:4px;line-height:18px;}
-// .btn-check:checked + .btn.tab{background-color:$M-gray2;color:$M-black;}
-// .active{
-//     .btn.tab{background-color:$M-gray2;color:$M-black;}
-// }
-
-button.tab{font-size:14px;color:$M-gray4;padding:8px 12px;margin-right:4px;border:none;background:none;border-radius:4px;line-height:18px;
-    &.active{background-color:$M-gray2;color:$M-black;}
-    &:last-child{margin-right:0;}
+.btn.tab{font-size:14px;color:$M-gray4;padding:8px 12px;border:none;background:none;border-radius:4px;line-height:18px;}
+.btn-check:checked + .btn.tab{background-color:$M-gray2;color:$M-black;}
+.active{
+    .btn.tab{background-color:$M-gray2;color:$M-black;}
 }
+
+// button.tab{font-size:14px;color:$M-gray4;padding:8px 12px;margin-right:4px;border:none;background:none;border-radius:4px;line-height:18px;
+//     &.active{background-color:$M-gray2;color:$M-black;}
+//     &:last-child{margin-right:0;}
+// }
 </style>

--- a/src/components/basic/BasicTable.vue
+++ b/src/components/basic/BasicTable.vue
@@ -1,42 +1,146 @@
 <template>
-    <div class="table-box">
-        <table>
-            <thead class="table-header">
-                <tr>
-                    <slot name="thead"></slot>
-                </tr>
-            </thead>
-            <tbody class="table-body">
-                <template v-for="row in list" :key="row">
-                    <tr>
-                        <slot name="tlist" :row="row"></slot>
-                    </tr>
-                </template>
-                <tr v-if="list.length === 0">
-                    <td colspan="30" class="txt-center">신청 내역이 없습니다.</td>
-                </tr>
-            </tbody>
-        </table>    
-    </div>
+  <div class="table-box">
+    <table>
+      <thead class="table-header">
+        <tr>
+          <slot name="thead"></slot>
+        </tr>
+      </thead>
+      <tbody class="table-body">
+        <template
+          v-for="row in list"
+          :key="row">
+          <tr>
+            <slot
+              name="tlist"
+              :row="row"></slot>
+          </tr>
+        </template>
+        <tr v-if="list.length === 0">
+          <td
+            colspan="30"
+            class="txt-center">
+            신청 내역이 없습니다.
+          </td>
+        </tr>
+      </tbody>
+    </table>    
+  </div>
 </template>
 
 <script>
+import { mapState, mapGetters } from 'vuex'
+
 export default {
-    data(){
-        return{
-            // 더미 데이터
-            list:[
-                {no:1,equipment:'Galaxy A9 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
-                {no:2,equipment:'Galaxy A10 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
-                {no:3,equipment:'Galaxy 11 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
-                {no:4,equipment:'Galaxy 12 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
-                {no:5,equipment:'Galaxy 13 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
-                {no:6,equipment:'Galaxy 14 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
-                {no:7,equipment:'Galaxy 15 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
-                {no:8,equipment:'Galaxy 16 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
-                {no:9,equipment:'Galaxy A9 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
-                {no:10,equipment:'Galaxy A9 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'}
-            ]
+    // props: {
+    //     list: {
+    //         type: Array,
+    //         default: () => []
+    //     }
+    // },
+    created() {
+        console.log('created', this.list)
+        this.fetchRentalHistory()
+    },
+    data() {
+        return {
+          // 더미 데이터
+          list: [
+              // {no:1,equipment:'Galaxy A9 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
+              // {no:2,equipment:'Galaxy A10 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
+              // {no:3,equipment:'Galaxy 11 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
+              // {no:4,equipment:'Galaxy 12 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
+              // {no:5,equipment:'Galaxy 13 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
+              // {no:6,equipment:'Galaxy 14 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
+              // {no:7,equipment:'Galaxy 15 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
+              // {no:8,equipment:'Galaxy 16 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
+              // {no:9,equipment:'Galaxy A9 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'},
+              // {no:10,equipment:'Galaxy A9 pro', device: '폰', OS:'Android 12', start:'2022.6.23',end:'2022.6.28',ModelNo:'SM-G997N',serialNo:'R59M107TG'}
+          ]
+        }
+    },
+    computed: {
+        ...mapGetters('equipments', [
+            'getRentalHistoryList',
+        ])
+    },
+    methods: {
+        fetchRentalHistory() {
+            console.log('MyApplyList.vue methods fetchRentalHistory')
+
+            const accessToken = localStorage.getItem('access_token')
+
+            if (accessToken) {
+                const decoded = this.$parseJwt(accessToken)
+                const params = {
+                    userId: Number(decoded.uid),
+                }
+
+                this.$store.dispatch('equipments/EQUIPMENT_RENTAL_HISTORY', params)
+                .then(response => {
+                    console.log('response', response)
+                    console.log('this.getRentalHistoryList', this.getRentalHistoryList)
+
+                    var _rentals = []
+                    var _rental = {
+                      no:10,
+                      equipment:'Galaxy A9 pro', 
+                      device: '폰', 
+                      OS:'Android 12', 
+                      start:'2022.6.23',
+                      end:'2022.6.28',
+                      ModelNo:'SM-G997N',
+                      serialNo:'R59M107TG',
+                      rentalStatusText:''
+                    }
+                    // 신청완료, 대여중, 연체
+
+                    response.forEach((row, i) => {
+                      console.log(row)
+
+                      _rental.no = i+1
+                      _rental.equipment = row.deviceName
+                      // _rental.device = row.deviceType
+                      _rental.OS = row.osName
+                      _rental.start = row.startRentalDate
+                      _rental.end = row.endRentalDate
+                      _rental.ModelNo = row.deviceModelNumber
+                      _rental.serialNo = row.deviceSerialNumber
+
+                      var deviceTypeText = ''
+                      if (row.deviceType == 'phone') {
+                        deviceTypeText = '휴대폰'
+                      }
+                      if (row.deviceType == 'tablet') {
+                        deviceTypeText = '태블릿'
+                      }
+                      if (row.deviceType == 'etc') {
+                        deviceTypeText = '기타'
+                      }
+                      _rental.device = deviceTypeText
+
+                      var rentalStatusText = ''
+                      if (row.rentalStatus == 1) {
+                        rentalStatusText = '신청 완료'
+                      }
+                      if (row.rentalStatus == 2) {
+                        rentalStatusText = '대여중'
+                      }
+                      if (row.rentalStatus == 3) {
+                        rentalStatusText = '연체'
+                      }
+                      _rental.rentalStatusText = rentalStatusText
+
+                      var _copied = Object.assign({}, _rental)
+        
+                      _rentals.push(_copied) 
+                    })
+
+                    this.list = _rentals
+                }) 
+            }
+
+
         }
     }
 }

--- a/src/components/basic/CardItem.vue
+++ b/src/components/basic/CardItem.vue
@@ -8,8 +8,8 @@
       <div class="item-state">
         <div v-if="equipment.isRented" class="rented">
           <span class="icon"></span>
-          <span class="txt">김지현</span>
-          <span class="date">2022.06.23</span>
+          <span class="txt">{{ equipment.user }}</span>
+          <span class="date">{{ equipment.date }}</span>
         </div>
         <div v-else class="select">
           <span v-if="!equipment.isSelected" class="txt">선택하기</span>
@@ -43,10 +43,18 @@ export default {
         type:Object,
         default(){
             return {
-                model:'model',
-                os: 'os',
-                isSelected:false,
-                isRented:false
+              name: 'name', // 기기명
+              manufacturer: 'model', // 제조사
+              os: 'os', // OS
+              type: 'phone', // 장비종류
+              modelNumber: '', // 모델 번호 : SM-960N
+              serialNumber: '', // 시리얼 번호 : R3CR10CZPOF
+              purchaseDate: '', // 구입일(인수일) : 2018. 11 .12.
+              description: '', // 비고 : 구입일 모름(인수일 기재) 본사에서 구입(라디오)
+              user: 'user',
+              date: 'date',
+              isSelected: false,
+              isRented: false
             }
         }
     }

--- a/src/components/basic/DatePicker.vue
+++ b/src/components/basic/DatePicker.vue
@@ -1,11 +1,15 @@
 <template>
   <div class="datapicker-box-item">
     <span class="txt">시작일</span>
-    <Datepicker v-model="startDate" />
+    <Datepicker 
+      v-model="date.start"
+      @update:modelValue="handleRentalStartDate" />
   </div>
     <div class="datapicker-box-item">
     <span class="txt">반납일</span>
-    <Datepicker v-model="endDate" />
+    <Datepicker 
+      v-model="date.end"
+      @update:modelValue="handleRentalEndDate" />
   </div>
 
 </template>
@@ -15,15 +19,43 @@ import Datepicker from "vue3-datepicker";
 
 export default {
   name: "DatePicker",
+  props: {
+    startDate: {
+      type: Date
+    },
+    endDate: {
+      type: Date
+    }
+  },
   data() {
     return {
       isFocused: false,
-      startDate: new Date(),
-      endDate: new Date()
+      date: {
+        start: new Date(),
+        end: new Date()
+      }
     };
   },
+
+  created() {
+    // props로 넘어온 값이 자식 컴포넌트에 세팅
+    this.date.start = this.startDate 
+    this.date.end = this.endDate
+  },
+
   components: {
     Datepicker,
+  },
+  methods: {
+    handleRentalStartDate() {
+      console.log('handleRentalStartDate', this.date.start)
+      this.$emit('onChangeDatePicker', this.date)
+    },
+
+    handleRentalEndDate() {
+      console.log('handleRentalEndDate', this.date.end)
+      this.$emit('onChangeDatePicker', this.date)
+    }
   }
 };
 </script>

--- a/src/components/header/UserInfo.vue
+++ b/src/components/header/UserInfo.vue
@@ -1,50 +1,79 @@
 <template>
   <div class="user-info">
-    <span class="name">김지현</span>
+    <span class="name">{{ user.name }}</span>
     <div class="dropdown">
-        <button class="btn" type="button" aria-expanded="false" @click="dropdown()"></button>
-        <ul class="dropdown-menu" :class="{'show' : isAddClass}">
-          <li v-for="menu in infoDropdown" :key="menu.name">
-            <RouterLink
-              :to="menu.href"
-              class="dropdown-item"
-              @click="dropdown()">
-              {{ menu.name }}
-            </RouterLink>
-          </li>
-        </ul> 
+      <button
+        class="btn"
+        type="button"
+        aria-expanded="false" 
+        @click="dropdown()"></button>
+      <ul 
+        class="dropdown-menu" 
+        :class="{'show' : isAddClass}">
+        <li
+          v-for="menu in infoDropdown" 
+          :key="menu.name">
+          <RouterLink
+            :to="menu.href"
+            class="dropdown-item"
+            @click="dropdown(menu)">
+            {{ menu.name }}
+          </RouterLink>
+        </li>
+      </ul> 
     </div>
   </div>
 </template>
 
 <script>
-export default{
-        data(){
-            return {
-                infoDropdown:[
-                // 관리자 페이지 작업후 href 수정 예정 2022-08-19 by.jyj
-                    {
-                        name : '내 정보', 
-                        href : '/mypage'
-                    },
-                    {
-                        name : '패스워드 변경',
-                        href : '/changepw'
-                    },
-                    {
-                        name : '로그아웃',
-                        href : '/about'
-                    },
-                ],
-                isAddClass : false
-            }
-        },
-        methods :{
-          dropdown (){
-            this.isAddClass = !this.isAddClass;
-          }
+import { mapState } from 'vuex'
+
+export default {
+  computed:{
+      ...mapState('members',[
+            'user',
+          ])
+      },
+    data(){
+        return {
+            infoDropdown:[
+            // 관리자 페이지 작업후 href 수정 예정 2022-08-19 by.jyj
+                {
+                    name : '내 정보', 
+                    href : '/mypage'
+                },
+                {
+                    name : '패스워드 변경',
+                    href : '/changepw'
+                },
+                {
+                    name : '로그아웃',
+                    href : '/'
+                },
+            ],
+            isAddClass : false
         }
+    },
+    // props:{
+    //     userInfo: {
+    //         type:Object,
+    //         default(){
+    //             return {
+    //                 name: '', // 기기명
+    //             }
+    //         }
+    //     }
+    // },
+    methods :{
+      dropdown(menu) {
+        console.log('dropdown', menu)
+        this.isAddClass = !this.isAddClass
+        if (menu && menu.name == '로그아웃') {
+          this.$store.dispatch('members/LOGOUT')
+        }
+      }
     }
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/layout/Header.vue
+++ b/src/components/layout/Header.vue
@@ -2,7 +2,9 @@
   <header :class="{'center':!signIn}"> <!-- 로그인 상태에서는 class="center" false -->
 
     <Logo />
-    <div class="nav nav-pills" v-if="signIn && manager">
+    <div
+      class="nav nav-pills"
+      v-if="loggedIn && administrator">
       <div 
         v-for="nav in navigation"
         :key="nav.name"
@@ -15,43 +17,51 @@
         </RouterLink>
       </div>
     </div>
-    <UserInfo v-if="signIn"/>
+    <UserInfo v-if="loggedIn" />
   </header>
 </template>
 
 <script>
 import Logo from '~/components/header/Logo'
 import UserInfo from '~/components/header/UserInfo'
+
+import { mapState } from 'vuex'
+
     export default{
       components:{
         Logo,
         UserInfo,
       },
-        data(){
-            return {
-                signIn : false,
-                manager : false,
-                navigation:[
-                  // 관리자 페이지 작업후 href 수정 예정 2022-08-19 by.jyj
-                    {
-                        name : '장비대여',
-                        href : '/main'
-                    },
-                    {
-                        name : '장비관리',
-                        href : '/movie'
-                    },
-                    {
-                        name : '수령확인',
-                        href : '/about'
-                    },
-                    {
-                        name : '계정관리',
-                        href : '/account'
-                    }
-                ]
-            }
-        }
+      data() {
+          return {
+              manager : false,
+              navigation:[
+                // 관리자 페이지 작업후 href 수정 예정 2022-08-19 by.jyj
+                  {
+                      name : '장비대여',
+                      href : '/main'
+                  },
+                  {
+                      name : '장비관리',
+                      href : '/movie'
+                  },
+                  {
+                      name : '수령확인',
+                      href : '/about'
+                  },
+                  {
+                      name : '계정관리',
+                      href : '/account'
+                  }
+              ]
+          }
+      },
+      computed:{
+      ...mapState('members',[
+            'loggedIn',
+            'administrator'
+          ])
+      },
     }
 </script>
 

--- a/src/components/main/MainTabs.vue
+++ b/src/components/main/MainTabs.vue
@@ -1,7 +1,8 @@
 <template>
     <!-- active 중복 불가 -->
     <div class="tab-nav">
-        <BasicTab v-for="(tab, i) in sortOption" :key="i" @click="activeTab(tab,i)" :tab="tab" :class="{active : tab.isActive}" >{{ tab.text }}</BasicTab>
+        <!-- <BasicTab v-for="(tab, i) in sortOption" :key="i" @click="activeTab(tab,i)" :tab="tab" :class="{active : tab.isActive}" >{{ tab.text }}</BasicTab> -->
+        <BasicTab v-for="(tab, i) in categories" :key="i"  @click="clickTab(tab, i)" :class="{active : tab.isActive}">{{ tab.text }}</BasicTab>
     </div>
 </template>
 
@@ -14,51 +15,50 @@ export default {
         BasicTab
     },
     data(){
-        return{
-            sortOption:[
+        return {
+            categories:[
                 { 
                     text : '전체',
-                    id:'option1',
-                    isActive : true
+                    code : 'all',
+                    isActive : false
                 },
                 { 
                     text : '대여가능',
-                    id:'option2',
+                    code : 'available',
                     isActive : false
                 },
                 { 
                     text : 'Android',
-                    id:'option3',                    
+                    code : 'android',
                     isActive : false
                 },
                 { 
                     text : 'iOS',
-                    id:'option4',                    
+                    code : 'ios',
                     isActive : false
                 },
                 { 
                     text : '폰',
-                    id:'option5',                    
+                    code : 'phone',
                     isActive : false
                 },
                 { 
                     text : '태블릿',
-                    id:'option6',                    
+                    code : 'tablet',
                     isActive : false
                 },
                 { 
                     text : '유심',
-                    id:'option7',                    
+                    code : 'usim',
                     isActive : false
                 },
                 { 
                     text : '기타',
-                    id:'option8',                    
+                    code : 'etc',
                     isActive : false
                 }
             ],
-                name:'sortOption'
-            }
+        }
     },
     methods:{
         activeTab(tab, i){
@@ -71,6 +71,20 @@ export default {
                 }
             })
             this.$emit("activeTab", tab)
+        },
+
+        clickTab(tab, i) {
+            console.log('MainTabs.vue clickTab', tab)
+            const selected = i
+            this.categories.forEach((tab, i) => {
+                if (i === selected) {
+                    console.log('i === selected')
+                    tab.isActive = true
+                } else {
+                    tab.isActive = false
+                }
+            })
+            this.$emit("clickTab", tab)
         }
     }
 }

--- a/src/components/main/MainTabs.vue
+++ b/src/components/main/MainTabs.vue
@@ -2,7 +2,7 @@
     <!-- active 중복 불가 -->
     <div class="tab-nav">
         <!-- <BasicTab v-for="(tab, i) in sortOption" :key="i" @click="activeTab(tab,i)" :tab="tab" :class="{active : tab.isActive}" >{{ tab.text }}</BasicTab> -->
-        <BasicTab v-for="(tab, i) in categories" :key="i"  @click="clickTab(tab, i)" :class="{active : tab.isActive}">{{ tab.text }}</BasicTab>
+        <BasicTab v-for="(tab, i) in categories" :key="i"  @click="clickTab(tab, i)" :tab="tab" :class="{active : tab.isActive}">{{ tab.text }}</BasicTab>
     </div>
 </template>
 

--- a/src/components/main/Search.vue
+++ b/src/components/main/Search.vue
@@ -32,9 +32,11 @@ export default {
     },
     methods:{
         searchItem(){
-            this.$store.dispatch('equipments/searchEquipment',{
-                keyword : this.keyword
-            })
+            // this.$store.dispatch('equipments/searchEquipment',{
+            //     keyword : this.keyword
+            // })
+
+            this.$emit("clickSearch", this.keyword)
         }
     }
 }

--- a/src/components/modal/CancelModal.vue
+++ b/src/components/modal/CancelModal.vue
@@ -1,15 +1,23 @@
 <template>
-    <div>
-        <div class="modal-content">
-            <div class="modal-body">
-                <p>해당 기기를 신청 목록에서<br>삭제하시겠습니까?</p>
-            </div>
-            <div class="modal-footer">
-                <BasicButton :class="{primary : true, lg: true}" >삭제</BasicButton>
-                <BasicButton :class="{white : true, lg: true}" @click="$emit('closeModal')">취소</BasicButton>
-            </div>
-        </div>
-    </div> 
+  <div>
+    <div class="modal-content">
+      <div class="modal-body">
+        <p>해당 기기를 신청 목록에서<br />삭제하시겠습니까?</p>
+      </div>
+      <div class="modal-footer">
+        <BasicButton
+          :class="{primary : true, lg: true}"
+          @click="deleteEquipment">
+          삭제
+        </BasicButton>
+        <BasicButton
+          :class="{white : true, lg: true}"
+          @click="closeModal">
+          취소
+        </BasicButton>
+      </div>
+    </div>
+  </div> 
 </template>
 
 <script>
@@ -17,6 +25,40 @@ import BasicButton from '~/components/basic/BasicButton'
 export default {
     components:{
         BasicButton
+    },
+    props: {
+        equipmentInfo: {
+            type: Object,
+            default() {
+                return {
+                    id: '0', 
+                    name: '', // 기기명
+                    manufacturer: '', // 제조사
+                    os: '', // OS
+                    type: '', // 장비종류
+                    modelNumber: '', // 모델 번호
+                    serialNumber: '', // 시리얼 번호
+                    purchaseDate: '', // 구입일(인수일)
+                    description: '', // 비고 : 구입일 모름(인수일 기재) 본사에서 구입(라디오)
+                    user: '',
+                    date: '',
+                    isSelected: false, 
+                    isRented: false,
+                    endRentalDate: '',
+                    rentalUser: ''
+                }
+            }
+        },
+    },
+    methods: {
+        deleteEquipment() {
+            console.log('CancelModal.vue deleteEquipment', this.equipmentInfo)
+            this.$emit('deleteEquipment', this.equipmentInfo)
+        },
+        closeModal() {
+            console.log('CancelModal.vue closeModal')
+            this.$emit('closeModal')
+        }
     }
 }
 </script>

--- a/src/components/modal/DetailModal.vue
+++ b/src/components/modal/DetailModal.vue
@@ -2,44 +2,44 @@
     <div class="detail-info">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title">{{equipmentInfo.model}}</h5>
+                <h5 class="modal-title">
+                    {{ equipmentInfo.model }}
+                </h5>
             </div>
             <div class="modal-body">
                 <dl>
                     <dt>제조사</dt>
-                    <dd>삼성</dd>
+                    <dd>{{ equipmentInfo.manufacturer }}</dd>
                 </dl>
                 <dl>
                     <dt>OS</dt>
-                    <dd>{{equipmentInfo.os}}</dd>
+                    <dd>{{ equipmentInfo.os }}</dd>
                 </dl>
                 <dl>
                     <dt>장비종류</dt>
-                    <dd>폰</dd>
+                    <dd>{{ equipmentInfo.type }}</dd>
                 </dl>
                 <dl>
                     <dt>모델번호</dt>
-                    <dd>SM-960N</dd>
+                    <dd>{{ equipmentInfo.modelNumber }}</dd>
                 </dl>
                 <dl>
                     <dt>시리얼 번호</dt>
-                    <dd>R3CR10CZPOF</dd>
+                    <dd>{{ equipmentInfo.serialNumber }}</dd>
                 </dl>
                 <dl>
                     <dt>구입일(인수일)</dt>
-                    <dd>2018. 11 .12.</dd>
+                    <dd>{{ equipmentInfo.purchaseDate }}</dd>
                 </dl>
                 <dl>
                     <dt>비고</dt>
-                    <dd>구입일 모름(인수일 기재) 본사에서 구입(라디오)</dd>
+                    <dd>{{ equipmentInfo.description }}</dd>
                 </dl>
-                
             </div>
             <div class="modal-footer">
                 <!-- 클릭시 applyList[]에 담기도록 작업 필요 -->
-                <BasicButton @click="aa" :class="{primary : true, lg:true , 'btn-cart-submit':true}" type="submit"><span class="icon"></span>신청하기</BasicButton>
+                <BasicButton @click="handleSubmit" :class="{primary : true, lg:true , 'btn-cart-submit':true}" type="submit"><span class="icon"></span>신청하기</BasicButton>
                 <BasicButton :class="{white : true, lg:true}" @click="$emit('closeModal')">닫기</BasicButton>
-
             </div>
         </div>
     </div>
@@ -60,16 +60,29 @@ export default {
             type:Object,
             default(){
                 return {
-                    model:'model',
-                    os: 'os',
-                    isSelected:false,
-                    isRented:false
+                    id: '0', 
+                    name: '', // 기기명
+                    manufacturer: '', // 제조사
+                    os: '', // OS
+                    type: '', // 장비종류
+                    modelNumber: '', // 모델 번호
+                    serialNumber: '', // 시리얼 번호
+                    purchaseDate: '', // 구입일(인수일)
+                    description: '', // 비고 : 구입일 모름(인수일 기재) 본사에서 구입(라디오)
+                    user: '',
+                    date: '',
+                    isSelected: false, 
+                    isRented: false,
+                    endRentalDate: '',
+                    rentalUser: ''
                 }
             }
         }
     },
     methods:{
-
+        handleSubmit() {
+            console.log('TODO')
+        }
     }
 }
 </script>

--- a/src/components/mypage/MyApplyList.vue
+++ b/src/components/mypage/MyApplyList.vue
@@ -1,34 +1,74 @@
 <template>
-    <BasicTable>
-        <template v-slot:thead>
-            <th>No.</th>
-            <th>장비명</th>
-            <th>종류</th>
-            <th>OS</th>
-            <th>대여 시작일</th>
-            <th>반납 예정일</th>
-            <th>모델(유심)번호</th>
-            <th>시리얼 번호</th>
-        </template>
-        <template v-slot:tlist="tlist">
-            <th>{{tlist.row.no}}</th>
-            <th>{{tlist.row.equipment}}</th>
-            <th>{{tlist.row.device}}</th>
-            <th>{{tlist.row.OS}}</th>
-            <th>{{tlist.row.start}}</th>
-            <th>{{tlist.row.end}}</th>
-            <th>{{tlist.row.ModelNo}}</th>
-            <th>{{tlist.row.serialNo}}</th>
-        </template>
-    </BasicTable>
+  <BasicTable>
+    <template #thead>
+      <th>No.</th>
+      <th>장비명</th>
+      <th>상태</th>
+      <th>종류</th>
+      <th>OS</th>
+      <th>대여 시작일</th>
+      <th>반납 예정일</th>
+      <th>모델(유심)번호</th>
+      <th>시리얼 번호</th>
+    </template>
+    <template #tlist="tlist">
+      <th>{{ tlist.row.no }}</th>
+      <th>{{ tlist.row.equipment }}</th>
+      <th>{{ tlist.row.rentalStatusText }}</th>
+      <th>{{ tlist.row.device }}</th>
+      <th>{{ tlist.row.OS }}</th>
+      <th>{{ tlist.row.start }}</th>
+      <th>{{ tlist.row.end }}</th>
+      <th>{{ tlist.row.ModelNo }}</th>
+      <th>{{ tlist.row.serialNo }}</th>
+    </template>
+  </BasicTable>
 </template>
 
 <script>
 import  BasicTable from '~/components/basic/BasicTable'
 
+// import { mapState, mapGetters } from 'vuex'
+
 export default {
     components:{
         BasicTable
+    },
+
+    created() {
+        console.log('MyApplyList.vue created')
+    },
+    // data() {
+    //     return {
+    //         rentalHistoryList: []
+    //     }
+    // },
+    // computed: {
+    //     ...mapGetters('equipments', [
+    //         'getRentalHistoryList',
+    //     ])
+    // },
+    methods: {
+        fetchRentalHistory() {
+            console.log('MyApplyList.vue methods fetchRentalHistory')
+
+            const accessToken = localStorage.getItem('access_token')
+
+            if (accessToken) {
+                const decoded = this.$parseJwt(accessToken)
+                const params = {
+                    userId: Number(decoded.uid),
+                }
+
+                this.$store.dispatch('equipments/EQUIPMENT_RENTAL_HISTORY', params)
+                .then(response => {
+                    console.log('response', response)
+                    console.log('this.getRentalHistoryList', this.getRentalHistoryList)
+                }) 
+            }
+
+
+        }
     }
 }
 </script>

--- a/src/components/sign/FormSignIn.vue
+++ b/src/components/sign/FormSignIn.vue
@@ -36,8 +36,6 @@
 import BasicButton from '~/components/basic/BasicButton'
 import IconButton from '~/components/basic/IconButton'
 
-import { api } from '~/api/api'
-
 export default {
     components:{
         BasicButton,
@@ -65,26 +63,32 @@ export default {
     },
     methods:{
         signInSubmit(){
-            // this.valid = true
-            // console.log(
-            //     this.signInData.nameSignIn,
-            //     this.signInData.pwSignIn,
-            //     this.succesed
-            // )
-            // if(this.valid){
-            //     this.succesed = true
-            //     this.$router.push('main')
-            // }
-
             this.$store.dispatch('members/LOGIN', this.signInData).then(response => {
                 console.log('signInSubmit response', response)
                 this.valid = true
-                this.$cookies.set("accessToken", response.access_token)
-                this.$router.push('main')
+                this.$router.replace('main')
             }).catch(error => {
                 console.log('catch error', error)
                 this.valid = false
-                alert('INTERNAL SERVER ERROR') // etc: Server Shutdown
+                if (error) {
+                    console.log('error', error)
+                    if (error.details) {
+                        console.log('error.details', error.details)
+                        error.details.forEach((target, i) => {
+                            console.log('error.details target: ' + target.field + ' | index: ' + i)
+                            if (target.field == 'empno') {
+                                alert(target.message)
+                            }
+                            if (target.field == 'password') {
+                                alert(target.message)
+                            }
+                        })
+                    } else {
+                        alert(error.message)
+                    }
+                } else {
+                    alert('INTERNAL SERVER ERROR') 
+                }
             })
         }
     }

--- a/src/components/sign/FormSignIn.vue
+++ b/src/components/sign/FormSignIn.vue
@@ -3,19 +3,19 @@
         <!-- validate 실패시 클래스 was-validated:invalid 추가 -->
         <form @submit="signInSubmit" class="input-box-signIn needs-validation">
             <div>
-                <input type="number" id="nameSignIn" v-model="signInData.nameSignIn" class="form-control" placeholder="사번" required>
+                <input type="number" id="nameSignIn" v-model="signInData.empno" class="form-control" placeholder="사번" required>
                 <label for="nameSignIn"></label>
-                <IconButton v-if="signInData.nameSignIn !== ''" :class="{close : true}" @click="signInData.nameSignIn = ''"></IconButton>
+                <IconButton v-if="signInData.empno !== ''" :class="{close : true}" @click="signInData.empno = ''"></IconButton>
                 <div class="invalid-feedback">이름을 다시 확인해주세요.</div>
             </div>
             <div>
-                <input type="password" id="pwSignIn" v-model="signInData.pwSignIn" class="form-control" placeholder="비밀번호" required>
+                <input type="password" id="pwSignIn" v-model="signInData.password" class="form-control" placeholder="비밀번호" required>
                 <label for="pwSignIn"></label>
-                <IconButton v-if="signInData.pwSignIn !== ''" :class="{close : true}" @click="signInData.pwSignIn = ''"></IconButton>
+                <IconButton v-if="signInData.password !== ''" :class="{close : true}" @click="signInData.password = ''"></IconButton>
                 <div class="invalid-feedback">비밀번호를 다시 확인해주세요.</div>
             </div>
             <div class="keep">
-                <input type="checkbox" id="keepSignIn" v-model="signInData.keepSignIn">
+                <input type="checkbox" id="keepSignIn" v-model="signInData.rememberMe">
                 <label for="keepSignIn" class="txt">로그인 상태 유지</label>
             </div>
         </form>
@@ -36,6 +36,8 @@
 import BasicButton from '~/components/basic/BasicButton'
 import IconButton from '~/components/basic/IconButton'
 
+import { api } from '~/api/api'
+
 export default {
     components:{
         BasicButton,
@@ -44,9 +46,9 @@ export default {
     data(){
         return{
             signInData:{
-                nameSignIn:'',
-                pwSignIn:'',
-                keepSignIn:false
+                empno:'',
+                password:'',
+                rememberMe:false
             },
             btnDisabled:true,
             valid:false,
@@ -56,23 +58,34 @@ export default {
     watch:{
         signInData:{
             handler(e){
-                e.nameSignIn !== "" && e.pwSignIn !== "" ? (this.btnDisabled = false) : (this.btnDisabled = true)
+                e.empno !== "" && e.password !== "" ? (this.btnDisabled = false) : (this.btnDisabled = true)
             },
             deep: true
         }
     },
     methods:{
         signInSubmit(){
-            this.valid = true
-            console.log(
-                this.signInData.nameSignIn,
-                this.signInData.pwSignIn,
-                this.succesed
-            )
-            if(this.valid){
-                this.succesed = true
+            // this.valid = true
+            // console.log(
+            //     this.signInData.nameSignIn,
+            //     this.signInData.pwSignIn,
+            //     this.succesed
+            // )
+            // if(this.valid){
+            //     this.succesed = true
+            //     this.$router.push('main')
+            // }
+
+            this.$store.dispatch('members/LOGIN', this.signInData).then(response => {
+                console.log('signInSubmit response', response)
+                this.valid = true
+                this.$cookies.set("accessToken", response.access_token)
                 this.$router.push('main')
-            }
+            }).catch(error => {
+                console.log('catch error', error)
+                this.valid = false
+                alert('INTERNAL SERVER ERROR') // etc: Server Shutdown
+            })
         }
     }
 }

--- a/src/components/sign/FormSignUp.vue
+++ b/src/components/sign/FormSignUp.vue
@@ -3,36 +3,64 @@
         <!-- validate 실패시 클래스 was-validated:invalid 추가 -->
         <form @submit="signUpSubmit" class="input-box-signUp needs-validation">
             <div>
-                <label for="nameSignUp">이름</label>
-                <input type="text" v-model="signUpData.nameSignUp" id="nameSignUp" class="form-control"  required>
+                <!-- <label for="nameSignUp">이름</label> -->
+                <!-- <input type="text" v-model="signUpData.nameSignUp" id="nameSignUp" class="form-control"  required> -->
+                <label for="user_name">이름</label>
+                <input type="text" v-model="signUpData.user_name" id="user_name" class="form-control"  required>
                 <div class="invalid-feedback">이름을 다시 확인해주세요.</div>
             </div>
             <div>
-                <label for="emailSignUp">회사 이메일</label>
+                <!-- <label for="emailSignUp">회사 이메일</label> -->
+                <label for="user_email">회사 이메일</label>
                 <div class="input-inside">
-                    <input type="text" v-model="signUpData.emailSignUp" id="emailSignUp" class="form-control"  required>
+                    <!-- <input type="text" v-model="signUpData.emailSignUp" id="emailSignUp" class="form-control"  required> -->
+                    <input type="text" v-model="signUpData.user_email" id="user_email" class="form-control" required>
                     <span class="inside-txt">@kbsmedia.co.kr</span>
                 </div>
                 <div class="invalid-feedback">등록되지 않은 이메일입니다.</div>
             </div>
             <div>
-                <label for="contactSignUp">휴대전화<span>-없이 입력</span></label>
-                <input type="number" v-model="signUpData.contactSignUp" id="contactSignUp" class="form-control"  required>
+                <!-- <label for="contactSignUp">휴대전화<span>-없이 입력</span></label> -->
+                <!-- <input type="number" v-model="signUpData.contactSignUp" id="contactSignUp" class="form-control"  required> -->
+                <label for="user_contact">휴대전화<span>-없이 입력</span></label>
+                <input type="text" 
+                    v-model="signUpData.user_contact" 
+                    id="user_contact" 
+                    class="form-control" 
+                    maxlength="11"
+                    @keypress="handleInputHpno" 
+                    @keydown="handleInputHpno" 
+                    @keyup="handleInputHpno" 
+                    required>
                 <div class="invalid-feedback">번호를 다시 확인해주세요.</div>
             </div>
             <div>
-                <label for="idSignUp">사번<span>5자리 입력</span></label>
-                <input type="number" v-model="signUpData.idSignUp" id="idSignUp" class="form-control" required>
+                <!-- <label for="idSignUp">사번<span>5자리 입력</span></label> -->
+                <!-- <input type="number" v-model="signUpData.idSignUp" id="idSignUp" class="form-control" required> -->
+                <label for="user_empno">사번<span>5자리 입력</span></label>
+                <input type="text" 
+                    v-model="signUpData.user_empno" 
+                    id="user_empno" 
+                    class="form-control" 
+                    maxlength="5" 
+                    @keypress="handleInputEmpno" 
+                    @keydown="handleInputEmpno" 
+                    @keyup="handleInputEmpno" 
+                    required>
                 <div class="invalid-feedback">등록되지 않은 사번입니다.</div>
             </div> 
             <div>
-                <label for="pwSignUp">비밀번호<span>최소 4글자 이상 입력</span></label>
-                <input type="password" v-model="signUpData.pwSignUp" id="pwSignUp" class="form-control"  required>
+                <!-- <label for="pwSignUp">비밀번호<span>최소 4글자 이상 입력</span></label> -->
+                <!-- <input type="password" v-model="signUpData.pwSignUp" id="pwSignUp" class="form-control"  required> -->
+                <label for="user_password">비밀번호<span>최소 4글자 이상 입력</span></label>
+                <input type="password" v-model="signUpData.user_password" id="user_password" class="form-control"  required>
                 <div class="invalid-feedback">최소 4자리 이상 입력해주세요.</div>
             </div>    
             <div>
-                <label for="pwConfirm">비밀번호<span>최소 4글자 이상 입력</span></label>
-                <input type="password" v-model="signUpData.pwConfirm" id="pwConfirm" class="form-control"  required>
+                <!-- <label for="pwConfirm">비밀번호<span>최소 4글자 이상 입력</span></label> -->
+                <!-- <input type="password" v-model="signUpData.pwConfirm" id="pwConfirm" class="form-control"  required> -->
+                <label for="user_password_confirm">비밀번호<span>최소 4글자 이상 입력</span></label>
+                <input type="password" v-model="signUpData.user_password_confirm" id="user_password_confirm" class="form-control"  required>
                 <div class="invalid-feedback">비밀번호가 일치하지 않습니다.</div>
             </div>
 
@@ -46,6 +74,7 @@
 
 <script>
 import BasicButton from '~/components/basic/BasicButton'
+import { api } from '~/api/api'
 
 export default {
     components:{
@@ -54,43 +83,345 @@ export default {
     data(){
         return{
             signUpData:{
-                nameSignUp:"",
-                emailSignUp:"",
-                contactSignUp:"",
-                idSignUp:"",
-                pwSignUp:"",
-                pwConfirm:""
+                // nameSignUp:"",
+                // emailSignUp:"",
+                // contactSignUp:"",
+                // idSignUp:"",
+                // pwSignUp:"",
+                // pwConfirm:""
+                user_name:"",
+                user_email:"",
+                user_contact:"",
+                user_empno:"",
+                user_password:"",
+                user_password_confirm:""
             },
             btnDisabled:true,
             valid:false,
-            succesed:false
-
+            succesed:false,
+            validation: {
+                signUpData: {
+                    isOk: false,
+                    user_name: false,
+                    user_email: false, 
+                    user_contact: false, 
+                    user_empno: false, 
+                    user_password_confirm: false, 
+                }
+            }
         }
     },
     watch:{
         signUpData:{
             handler(e){
-                e.nameSignUp !== "" && e.emailSignUp !== ""  && e.contactSignUp !== "" && e.idSignUp !== "" && e.pwSignUp !== "" && e.pwConfirm !== "" ? (this.btnDisabled = false) : (this.btnDisabled = true)
+                // e.nameSignUp !== "" && e.emailSignUp !== ""  && e.contactSignUp !== "" && e.idSignUp !== "" && e.pwSignUp !== "" && e.pwConfirm !== "" ? (this.btnDisabled = false) : (this.btnDisabled = true)
+                e.user_name !== "" && e.user_email !== ""  && e.user_contact !== "" && e.user_empno !== "" && e.user_password !== "" && e.user_password_confirm !== "" ? (this.btnDisabled = false) : (this.btnDisabled = true)
             },
             deep: true
         }
     },
     methods:{
-        signUpSubmit(){
-            console.log(
-                this.signUpData.nameSignUp,
-                this.signUpData.emailSignUp,
-                this.signUpData.contactSignUp,
-                this.signUpData.idSignUp,
-                this.signUpData.pwSignUp,
-                this.signUpData.pwConfirm,
-                this.succesed
-            )
-            if(this.valid){
-                this.succesed = true
-                this.$router.push('Succesed')
+        // signUpSubmit(){
+        //     console.log(
+        //         this.signUpData.nameSignUp,
+        //         this.signUpData.emailSignUp,
+        //         this.signUpData.contactSignUp,
+        //         this.signUpData.idSignUp,
+        //         this.signUpData.pwSignUp,
+        //         this.signUpData.pwConfirm,
+        //         this.succesed
+        //     )
+        //     if(this.valid){
+        //         this.succesed = true
+        //         this.$router.push('Succesed')
+        //     }
+        // }
+
+        isInputOnlyNumber(event) {
+            event = (event) ? event : window.event;
+            var charCode = (event.which) ? event.which : event.keyCode;
+            if ((charCode > 31 && (charCode < 48 || charCode > 57)) && charCode !== 46) {
+                event.preventDefault()
+                return false
+            } else {
+                return true
             }
+        },
+
+        // input type number 사용 시 input a -> input b 이동하여 key 입력하는 순간 input a의 맨 앞 한 글자가 삭제되는 버그 발생
+        handleInputHpno(event) {
+            event = (event) ? event : window.event;
+            if (this.isInputOnlyNumber(event)) {
+                if (event.target.value.length > event.target.maxLength) {
+                    event.preventDefault()
+                    event.target.value = event.target.value.slice(0, event.target.maxLength)
+                }
+            }
+        },
+
+        handleInputEmpno(event) {
+            event = (event) ? event : window.event;
+            if (this.isInputOnlyNumber(event)) {
+                if (event.target.value.length > event.target.maxLength) {
+                    event.preventDefault()
+                    event.target.value = event.target.value.slice(0, event.target.maxLength)
+                }
+            }
+        },
+
+        checkSignUpDataBeforeSubmit() {
+            this.checkUserName()
+            this.checkUserEmail()
+            this.checkUserContact()
+            this.checkUserEmpNo()
+            this.checkUserPassword()
+
+            this.validation.signUpData.isOk = this.validation.signUpData.user_name 
+                                                && this.validation.signUpData.user_email
+                                                && this.validation.signUpData.user_contact
+                                                && this.validation.signUpData.user_empno
+                                                && this.validation.signUpData.user_password
+                                                && this.validation.signUpData.user_password_confirm
+
+            return this.validation.signUpData.isOk
+        },
+
+        checkUserName() {
+            // 이름
+            if (this.signUpData.user_name) {
+                this.validation.signUpData.user_name = true
+            } else {
+                this.validation.signUpData.user_name = false
+                console.log('check 이름')
+            }
+        },
+
+        checkUserEmail() {
+            // 회사 이메일
+            if (this.signUpData.user_email) {
+                const patternPhone = /^[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_\.]?[0-9a-zA-Z])*\.[a-zA-Z]{2,3}$/i
+                if (patternPhone.test(this.signUpData.user_email + '@kbsmedia.co.kr')) {
+                    this.validation.signUpData.user_email = true
+                } else {
+                    this.validation.signUpData.user_email = false
+                    console.log('check 회사 이메일 정규식')
+                }
+                this.validation.signUpData.user_email = true
+            } else {
+                this.validation.signUpData.user_email = false
+                console.log('check 회사 이메일')
+            }
+        },
+
+        checkUserContact() {
+            // 휴대전화
+            if (this.signUpData.user_contact) {
+                const patternPhone = /01[016789][^0][0-9]{2,3}[0-9]{3,4}/
+                if (patternPhone.test(this.signUpData.user_contact)) {
+                    this.validation.signUpData.user_contact = true
+                } else {
+                    this.validation.signUpData.user_contact = false
+                    console.log('check 휴대전화 정규식')
+                }
+            } else {
+                this.validation.signUpData.user_contact = false
+                console.log('check 휴대전화')
+            }
+        },
+
+        checkUserEmpNo() {
+            // 사번
+            if (this.signUpData.user_empno) {
+                if (this.signUpData.user_empno.length == 5) {
+                    this.validation.signUpData.user_empno = true
+                } else {
+                    this.validation.signUpData.user_empno = false
+                    console.log('check 사번 길이')
+                }
+            } else {
+                this.validation.signUpData.user_empno = false
+                console.log('check 사번')
+            }
+        },
+
+        checkUserPassword() {
+            // 비밀번호
+            if (this.signUpData.user_password) {
+                if (this.signUpData.user_password.length >= 4) {
+                    this.validation.signUpData.user_password = true
+                } else {
+                    this.validation.signUpData.user_password = false
+                    console.log('check 비밀번호 길이')
+                }
+            } else {
+                this.validation.signUpData.user_password = false
+                console.log('check 비밀번호')
+            }
+            // 비밀번호 확인
+            if (this.signUpData.user_password_confirm) {
+                if (this.signUpData.user_password_confirm.length >= 4) {
+                    this.validation.signUpData.user_password_confirm = true
+                } else {
+                    this.validation.signUpData.user_password_confirm = false
+                    console.log('check 비밀번호 확인 길이')
+                }
+            } else {
+                this.validation.signUpData.user_password_confirm = false
+                console.log('check 비밀번호 확인')
+            }
+            // 비밀번호 && 비밀번호 확인
+            if (this.signUpData.user_password === this.signUpData.user_password_confirm) {
+                this.validation.signUpData.user_password = true
+                this.validation.signUpData.user_password_confirm = true
+            } else {
+                this.validation.signUpData.user_password = false
+                this.validation.signUpData.user_password_confirm = false
+                console.log('check 비밀번호 && 비밀번호 확인')
+            }
+        },
+
+        makeSignUpData() {
+            const copiedData = Object.assign({}, this.signUpData)
+            copiedData.user_email = copiedData.user_email + '@kbsmedia.co.kr'
+            return copiedData
+        },
+
+        signUpSubmit() {
+            this.btnDisabled = true
+            if (this.checkSignUpDataBeforeSubmit()) {
+                const data = this.makeSignUpData()
+                api.signUp(data).then(response => {
+                    console.log('response', response)
+                    if (response) {
+                        // 계정 생성
+                        if (response.status == 201) { // CREATED
+                            console.log('response.data', response.data)
+                            console.log('response.headers', response.headers)
+
+                            alert('계정 등록이 완료되었습니다.')
+
+                            const signInData = {
+                                empno: this.signUpData.user_empno,
+                                password: this.signUpData.user_password
+                            }
+
+                            this.signInSubmit(signInData)
+
+                            console.log('response.data', this.signUpData.user_empno)
+                            console.log('response.data', this.signUpData.user_password)
+                            
+
+                        }
+
+                        // 계정 생성
+                        if (response.status == 200) {
+                            if (response.data.isSuccessful) {
+                                console.log('response.data.isSuccessful == true')
+                            } else {
+                                console.log('response.data.isSuccessful == false')
+                                if (response.data.error) {
+                                    console.log('response.data.error', response.data.error)
+                                    if (response.data.error.message == 'User already exist') {
+                                        alert('이미 등록된 사용자입니다.')
+                                    }
+                                }
+                            }
+                        }
+
+                        // if (response.status == 200) {
+                        //     if (response.data.isSuccessful) {
+                        //         console.log('response.data.isSuccessful == true')
+                        //     } else {
+                        //         console.log('response.data.isSuccessful == false')
+                        //     }
+                        // }
+                        // else if (response.status == 400) {
+                        //     if (response.data.error) {
+                        //         console.log('response.data.error', response.data.error)
+                        //         console.log('response.data.error.message', response.data.error.message)
+                        //     }
+
+                        //     if (response.data.errors) {
+                        //         response.data.errors.forEach(function(item) {
+                        //             console.log(item);
+                        //         });
+                        //     }
+                        // }
+
+                    } else {
+                        this.valid = false
+
+                        console.log('else response', response)
+
+                        if (response.data.error) {
+                            // 이미 등록된 사용자입니다.
+
+                            console.log('response.data.error', response.data.error)
+                            console.log('response.data.error.message', response.data.error.message)
+
+                            if (response.data.error.message == 'User already exist') {
+                                alert('이미 등록된 사용자입니다.') // etc: Server Shutdown, java.sql.SQLSyntaxErrorException
+                            }
+                            // 확인되지 않은 사용자입니다.
+                        }
+
+                        console.log('TODO 오류 발생') // etc: Server Shutdown, java.sql.SQLSyntaxErrorException
+                    }
+
+                    this.btnDisabled = false
+
+                }).catch(error => {
+                    console.log('catch error', error)
+                    this.valid = false
+                    alert('TODO 예외 발생')
+                    this.btnDisabled = false
+                })
+            }
+        },
+
+        signInSubmit(signInData) {
+            api.signIn(signInData).then(response => {
+                console.log(response)
+                if (response && response.status == 200) {
+                    if (response.data) {
+                        if (response.data.access_token) {
+
+                            console.log('response.data.access_token', response.data.access_token)
+
+                            this.valid = true
+                            this.$cookies.set("accessToken", response.data.access_token); // 1일 후에 만료되는 jwt 이름으로 jwt value 저장
+
+                            const a = this.$cookies.get("accessToken")
+
+                            console.log('a', a)
+
+                            this.$router.push('main')
+                        } 
+                        else { 
+                            this.valid = false
+                            if (response.data.error) {
+                                if (response.data.error.field == 'empno') {
+                                    alert('등록되지 않은 사용자입니다. 아래 \'계정 등록\' 버튼을 눌러 계정을 등록해주세요.')
+                                } else if (response.data.error.field == 'password') {
+                                    alert('비밀번호가 올바르지 않습니다.')
+                                }
+                            }
+                        }
+                    } else {
+                        this.valid = false
+                    }
+                } else {
+                    console.log('response', response)
+                    this.valid = false
+                    alert('TODO 오류 발생') // etc: Server Shutdown
+                }
+            }).catch(error => {
+                console.log('catch error', error)
+                this.valid = false
+                alert('TODO 예외 발생')
+            })
         }
+
     }
 }
 </script>

--- a/src/main.js
+++ b/src/main.js
@@ -7,9 +7,14 @@ import Datepicker from '@vuepic/vue-datepicker';
 // import 'element-plus/dist/index.css'
 // import "@/styles/main.css"
 
-createApp(App)
+import VueCookie from 'vue-cookies'
+
+const app = createApp(App)
     .component('Datepicker', Datepicker)
     // .use(ElementPlus)
     .use(router)
     .use(store)
+    .use(VueCookie)
     .mount('#app')
+
+ app.$cookies.config('1d') // 쿠키의 만료일은 1일 (글로벌 세팅)

--- a/src/main.js
+++ b/src/main.js
@@ -7,14 +7,16 @@ import Datepicker from '@vuepic/vue-datepicker';
 // import 'element-plus/dist/index.css'
 // import "@/styles/main.css"
 
-import VueCookie from 'vue-cookies'
+// import VueCookie from 'vue-cookies'
+import common from './common/common.js'
 
-const app = createApp(App)
+createApp(App)
     .component('Datepicker', Datepicker)
     // .use(ElementPlus)
     .use(router)
+    .use(common)
+    // .use(VueCookie)
     .use(store)
-    .use(VueCookie)
     .mount('#app')
 
- app.$cookies.config('1d') // 쿠키의 만료일은 1일 (글로벌 세팅)
+//  app.$cookies.config('1d') // 쿠키의 만료일은 1일 (글로벌 세팅)

--- a/src/routes/MyPage.vue
+++ b/src/routes/MyPage.vue
@@ -10,15 +10,16 @@
           :key="i"
           :tab="tab"
           @click="activeTab(tab,i)"
-          :class="{active : tab.isActive}">
+          :class="{active : tab.isActive}"
+          ref="basicTab">
           {{ tab.text }}
         </BasicTab>
       </div>
     </template>
   </ContentTop>
   <ContentBottom>
-    <template #content >
-      <component :is="currentView"></component>
+    <template #content>
+      <component :is="currentView" />
     </template>
   </ContentBottom>
 </template>
@@ -38,9 +39,9 @@ export default {
         MyApplyList,
         BasicTab
     },
-    data(){
-      return{
-        tabs:[
+    data() {
+      return {
+        tabs: [
           { 
               text : '계정 정보',
               isActive : true,
@@ -52,21 +53,37 @@ export default {
               content:'MyApplyList'
           }
         ],
-        currentView:'MyAccountInfo'
+        currentView: 'MyAccountInfo'
       }
     },
-    methods:{
-        activeTab(tab, i){
-            const seleted = i
-            this.tabs.forEach((tab, i)=>{
-                if(i === seleted){
-                    tab.isActive = true
-                }else{
-                    tab.isActive = false
-                }
-            })
-            this.currentView = tab.content
+    mounted() {
+      console.log('MyPage.vue mounted')
+      console.log(this.$route.query.tab)
+      if ('MyApplyList' == this.$route.query.tab) {
+        this.handleFromRentRequestDone()
+      }
+      
+    },
+    methods: {
+        handleFromRentRequestDone() {
+          console.log('MyPage.vue methods handleFromRentRequestDone')
+          this.activeTab(this.tabs[1], 1)
+        },
+
+        activeTab(tab, i) {
+          console.log('MyPage.vue methods activeTab', tab, 'index', i)
+          const seleted = i
+          this.tabs.forEach((tab, i)=>{
+              if(i === seleted){
+                  tab.isActive = true
+              }else{
+                  tab.isActive = false
+              }
+          })
+          this.currentView = tab.content
         }
+
+        
     }
 }
 </script>

--- a/src/routes/RentRequestDone.vue
+++ b/src/routes/RentRequestDone.vue
@@ -1,0 +1,60 @@
+<template>
+  <div class="sign-container"> 
+    <div class="inner">
+
+        <div class="succesed-msg">
+            <img src="~/assets/icon-b-check.png" alt="">
+            <p class="txt">대여신청이 완료되었습니다.<br />담당자 확인 후 신청한 기기를 찾아가주세요.</p>
+        </div>
+        
+        <div class="succesed-btns">
+          <BasicButton :class="{primary : true, lg: true, mn: true}" @click="onClickOk">확인</BasicButton>
+          <BasicButton :class="{white : true, lg: true, mn: true}" @click="onClickRequestHistory">신청 내역 조회하기</BasicButton>
+        </div>
+    </div><!-- /.inner -->
+  </div><!-- /.sign-container -->
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import BasicButton from '~/components/basic/BasicButton'
+
+export default {
+  components:{
+    BasicButton
+  },
+  computed:{
+    ...mapState('members',[
+      'succesedMsg'
+    ])
+  },
+  methods: {
+    onClickOk() {
+      this.$router.replace('/main')
+    },
+
+    onClickRequestHistory() {
+      console.log('신청 내역 조회하기')
+      this.$router.push({path: '/mypage', query: {tab: 'MyApplyList'}})
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.sign-container{
+  @include landscape{justify-content:center;padding-top:0px;}
+  .inner{text-align:center;
+    .succesed-msg{margin-bottom:80px;
+        img{width:120px;height:120px;}
+        .txt{font-size:24px;color:$M-gray5;margin-top:40px;
+        @include portrait{font-size:16px;margin-top:24px;}
+        }
+    }
+    .succesed-btns{
+      button + button{margin-top:16px;}
+      @include landscape{position:absolute;bottom:24px;left:16px;width:94%;}
+    }
+  }
+}
+</style>

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,4 +1,4 @@
-import { createRouter, createWebHashHistory } from 'vue-router'
+import { createRouter, createWebHistory, createWebHashHistory } from 'vue-router'
 import Main from './Main'
 import Movie from './Movie'
 import About from './About'
@@ -10,43 +10,50 @@ import SignIn from './SignIn'
 import SignUp from './SignUp'
 import SignFind from './SignFind'
 import Success from './Success'
+import RentRequestDone from './RentRequestDone'
 // import SignUp from './SignUp'
 // import SignFind from './SignFind'
 
+function parseJwt (token) {
+    console.log('index.js token', token)
+    var base64Url = token.split('.')[1]
+    var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+    var jsonPayload = decodeURIComponent(window.atob(base64).split('').map(function(c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+    }).join(''))
+
+    return JSON.parse(jsonPayload)
+}
+
+// NavigationGuard
+const requireAuth = () => (from, to, next) => {
+    // const token = localStorage.getItem('user_token')
+    const accessToken = localStorage.getItem('access_token')
+
+    if (accessToken) {
+        const payload = parseJwt(accessToken)
+        if (payload.exp < Date.now() / 1000) { // 액세스토큰 만료
+            localStorage.removeItem('access_token')
+            next('/')
+        } else {  // 페이지 이동
+            return next()
+        }
+    } else {
+        next('/') // 로그인 화면으로 이동
+    }
+
+    // const isAuthenticated = false
+    // if (isAuthenticated) return next()
+    // next('/?returnPath=main')
+}
 
 export default createRouter({
     //Hash 모드
     history: createWebHashHistory(),
 
+    // history: createWebHistory(),
+
     routes: [
-        {
-            path: '/main',
-            component: Main
-        },
-        {
-            path: '/movie',
-            component: Movie
-        },
-        {
-            path: '/about',
-            component: About
-        },
-        {
-            path: '/account',
-            component: Account
-        },
-        {
-            path: '/mypage',
-            component: MyPage
-        },
-        {
-            path: '/rentApply',
-            component: RentApply
-        },
-        {
-            path: '/changepw',
-            component: ChangePw
-        },
         {
             path: '/',
             component: SignIn
@@ -60,8 +67,47 @@ export default createRouter({
             component : SignFind
         },
         {
+            path: '/main',
+            component: Main,
+            beforeEnter: requireAuth()
+        },
+        {
+            path: '/movie',
+            component: Movie
+        },
+        {
+            path: '/about',
+            component: About,
+            beforeEnter: requireAuth()
+        },
+        {
+            path: '/account',
+            component: Account,
+            beforeEnter: requireAuth()
+        },
+        {
+            path: '/mypage',
+            component: MyPage,
+            beforeEnter: requireAuth(),
+            props: true
+        },
+        {
+            path: '/rentApply',
+            component: RentApply
+        },
+        {
             path: '/success',
-            component : Success
-        }
+            component : Success,
+            beforeEnter: requireAuth()
+        },
+        {
+            path: '/rent/request/done',
+            component : RentRequestDone,
+            beforeEnter: requireAuth()
+        },
+        {
+            path: '/changepw',
+            component: ChangePw
+        },
     ]
 })

--- a/src/store/equipments.js
+++ b/src/store/equipments.js
@@ -1,4 +1,5 @@
-import axios from 'axios'
+import { api } from '~/api/api'
+import VueCookies from 'vue-cookies'
 
 const _successdMsg = '완료되었습니다.'
 
@@ -9,20 +10,103 @@ export default{
         applyList : [],
         successdMsg : _successdMsg,
         loading : false,
+        tab : '',
         keyword : '',
-        countSearchItem:0,
+        countSearchItem : 0,
         countApplyItem : 0
-
     }),
-    getters:{},
+    getters:{
+
+        getEquipmentList(state) {
+            return state.equipmentList
+        }
+
+    },
     mutations:{
         updateState(state, payload){
-            Object.keys(payload).forEach(key => {
-                state[key] = payload[key]
-            })
-        }
+            // Object.keys(payload).forEach(key => {
+            //     state[key] = payload[key]
+            // })
+
+            state.applyList = payload.applyList
+            state.countItem = payload.countItem
+        },
+
+        updateEquipmentList(state, payload) {
+            console.log('equipments.js mutations updateEquipmentList')
+            console.log('    > equipments.js mutations updateEquipmentList state', state)
+            console.log('    > equipments.js mutations updateEquipmentList payload', payload)
+            state.equipmentList = payload
+            state.countSearchItem = payload.length
+        },
     },
     actions:{
+
+        // API - 장비목록 조회
+        async EQUIPMENT_SEARCH({ state, commit }, payload) {
+
+            console.log('equipments.js actions async searchEquipment state', state)
+            console.log('equipments.js actions async searchEquipment commit', commit)
+            console.log('    > equipments.js actions async searchEquipment payload', payload)
+
+            const accessToken = VueCookies.get('accessToken')
+
+            const response = await api.getDevices(payload, accessToken)
+
+            var _equipmentList = []
+            var _equipment = { 
+                id: '0', 
+                name: '', // 기기명
+                manufacturer: '', // 제조사
+                os: '', // OS
+                type: '', // 장비종류
+                modelNumber: '', // 모델 번호
+                serialNumber: '', // 시리얼 번호
+                purchaseDate: '', // 구입일(인수일)
+                description: '', // 비고 : 구입일 모름(인수일 기재) 본사에서 구입(라디오)
+                user: '',
+                date: '',
+                isSelected: false, 
+                isRented: false,
+                endRentalDate: '',
+                rentalUser: ''
+            }
+
+            for (var key in response.data) {
+                var _row = []
+                _row = response.data[key]
+
+                // console.log('_row', _row)
+
+                _equipment.id = _row.deviceId // 기기 ID
+                _equipment.model = _row.deviceName // 기기명
+                _equipment.os = _row.deviceOsName // OS
+                _equipment.type = _row.deviceType
+                _equipment.manufacturer = _row.deviceManufacturer
+                _equipment.serialNumber = _row.deviceSerialNumber
+                _equipment.modelNumber = _row.deviceModelNumber
+
+                _equipment.purchaseDate = _row.devicePurchaseDate
+
+                _equipment.description = _row.deviceDescription
+
+                _equipment.endRentalDate = _row.endRentalDate
+                _equipment.rentalUser = _row.rentalUser
+
+                // _equipment.description = _row.deviceDescription // 비고
+                _equipment.user = _row.rentalUser // 대여자 이름
+                _equipment.date = _row.endRentalDate // 반납예정일
+                _equipment.status = _row.rentalStatus // 대여상태 [신청 완료(0) / 대여중(1) / 연체(2) / 반납완료(3) ]
+                _equipment.isRented = _row.rentalId && _row.rentalId > 0 ? true : false // 대여여부
+
+                var _copied = Object.assign({}, _equipment)
+
+                _equipmentList.push(_copied) 
+            }
+
+            commit("updateEquipmentList", _equipmentList)
+        },
+
         async searchEquipment({ state, commit }, payload){
             const res = payload.keyword
             commit('updateState',{

--- a/src/store/equipments.js
+++ b/src/store/equipments.js
@@ -29,7 +29,7 @@ export default{
             // })
 
             state.applyList = payload.applyList
-            state.countItem = payload.countItem
+            state.countApplyItem = payload.countApplyItem
         },
 
         updateEquipmentList(state, payload) {

--- a/src/store/equipments.js
+++ b/src/store/equipments.js
@@ -1,5 +1,4 @@
 import { api } from '~/api/api'
-import VueCookies from 'vue-cookies'
 
 const _successdMsg = '완료되었습니다.'
 
@@ -8,6 +7,7 @@ export default{
     state:()=>({
         equipmentList: [],
         applyList : [],
+        rentalHistoryList: [],
         successdMsg : _successdMsg,
         loading : false,
         tab : '',
@@ -19,10 +19,32 @@ export default{
 
         getEquipmentList(state) {
             return state.equipmentList
+        },
+
+        getRentalHistoryList(state) {
+            return state.rentalHistoryList
         }
 
     },
     mutations:{
+
+        EQUIPMENT_RENTAL_REQUEST_SUCCESS() {
+            console.log('equipments.js mutations EQUIPMENT_RENTAL_REQUEST_SUCCESS')
+        },
+
+        EQUIPMENT_RENTAL_REQUEST_FAIL() {
+            console.log('equipments.js mutations EQUIPMENT_RENTAL_REQUEST_FAIL')
+        },
+
+        EQUIPMENT_RENTAL_HISTORY_SUCCESS(state, payload) {
+            console.log('equipments.js mutations EQUIPMENT_RENTAL_HISTORY_SUCCESS', payload)
+            state.rentalHistoryList = payload
+        },
+
+        EQUIPMENT_RENTAL_HISTORY_FAIL() {
+            console.log('equipments.js mutations EQUIPMENT_RENTAL_HISTORY_FAIL')
+        },
+
         updateState(state, payload){
             // Object.keys(payload).forEach(key => {
             //     state[key] = payload[key]
@@ -38,82 +60,257 @@ export default{
             console.log('    > equipments.js mutations updateEquipmentList payload', payload)
             state.equipmentList = payload
             state.countSearchItem = payload.length
+            state.applyList = []
+            state.countApplyItem = 0
         },
     },
     actions:{
 
         // API - 장비목록 조회
         async EQUIPMENT_SEARCH({ state, commit }, payload) {
+            console.log('equipments.js actions EQUIPMENT_SEARCH')
+            return new Promise((resolve, reject) => {
 
-            console.log('equipments.js actions async searchEquipment state', state)
-            console.log('equipments.js actions async searchEquipment commit', commit)
-            console.log('    > equipments.js actions async searchEquipment payload', payload)
+                console.log('equipments.js actions async EQUIPMENT_SEARCH state', state)
+                console.log('equipments.js actions async EQUIPMENT_SEARCH commit', commit)
+                console.log('    > equipments.js actions async EQUIPMENT_SEARCH payload', payload)
+    
+                api.getDevices(payload)
+                // .then(response => response.data)
+                .then(response => {
+        
+                    console.log('111 response', response)
 
-            const accessToken = VueCookies.get('accessToken')
+                    var list = response && response.data ? response.data : []
 
-            const response = await api.getDevices(payload, accessToken)
+                    console.log('list', list)
 
-            var _equipmentList = []
-            var _equipment = { 
-                id: '0', 
-                name: '', // 기기명
-                manufacturer: '', // 제조사
-                os: '', // OS
-                type: '', // 장비종류
-                modelNumber: '', // 모델 번호
-                serialNumber: '', // 시리얼 번호
-                purchaseDate: '', // 구입일(인수일)
-                description: '', // 비고 : 구입일 모름(인수일 기재) 본사에서 구입(라디오)
-                user: '',
-                date: '',
-                isSelected: false, 
-                isRented: false,
-                endRentalDate: '',
-                rentalUser: ''
-            }
+                    var _equipmentList = []
+                    var _equipment = { 
+                        id: '', 
+                        name: '', // 기기명
+                        manufacturer: '', // 제조사
+                        os: '', // OS
+                        type: '', // 장비종류
+                        modelNumber: '', // 모델 번호
+                        serialNumber: '', // 시리얼 번호
+                        purchaseDate: '', // 구입일(인수일)
+                        description: '', // 비고 : 구입일 모름(인수일 기재) 본사에서 구입(라디오)
+                        user: '',
+                        date: '',
+                        isSelected: false, 
+                        isRented: false,
+                        endRentalDate: '',
+                        rentalUser: ''
+                    }
 
-            for (var key in response.data) {
-                var _row = []
-                _row = response.data[key]
+                    for (var key in list) {
+                        var _row = []
+                        _row = list[key]
+        
+                        _equipment.id = _row.deviceId // 기기 ID
+                        _equipment.model = _row.deviceName // 기기명
+                        _equipment.os = _row.deviceOsName // OS
+                        _equipment.type = _row.deviceType
+                        _equipment.manufacturer = _row.deviceManufacturer
+                        _equipment.serialNumber = _row.deviceSerialNumber
+                        _equipment.modelNumber = _row.deviceModelNumber
+        
+                        _equipment.purchaseDate = _row.devicePurchaseDate
+        
+                        _equipment.description = _row.deviceDescription
+        
+                        _equipment.endRentalDate = _row.endRentalDate
+                        _equipment.rentalUser = _row.rentalUser
+        
+                        // _equipment.description = _row.deviceDescription // 비고
+                        _equipment.user = _row.rentalUser // 대여자 이름
+                        _equipment.date = _row.endRentalDate // 반납예정일
+                        _equipment.status = _row.rentalStatus // 대여상태 [신청 완료(0) / 대여중(1) / 연체(2) / 반납완료(3) ]
+                        _equipment.isRented = _row.rentalId && _row.rentalId > 0 ? true : false // 대여여부
+        
+                        var _copied = Object.assign({}, _equipment)
+        
+                        _equipmentList.push(_copied) 
+                    }
 
-                // console.log('_row', _row)
+                    commit("updateEquipmentList", _equipmentList)
+                    resolve(_equipmentList)
 
-                _equipment.id = _row.deviceId // 기기 ID
-                _equipment.model = _row.deviceName // 기기명
-                _equipment.os = _row.deviceOsName // OS
-                _equipment.type = _row.deviceType
-                _equipment.manufacturer = _row.deviceManufacturer
-                _equipment.serialNumber = _row.deviceSerialNumber
-                _equipment.modelNumber = _row.deviceModelNumber
+                })
+                .catch(error => {
+                    console.log('error', error)
 
-                _equipment.purchaseDate = _row.devicePurchaseDate
+                    if (error.response) {
+                        // 요청이 이루어졌으며 서버가 2xx의 범위를 벗어나는 상태 코드로 응답했습니다.
+                        console.log(error.response.data);
+                        console.log(error.response.status);
+                        console.log(error.response.headers);
+                    }
+                    else if (error.request) {
+                        // 요청이 이루어 졌으나 응답을 받지 못했습니다.
+                        // `error.request`는 브라우저의 XMLHttpRequest 인스턴스 또는
+                        // Node.js의 http.ClientRequest 인스턴스입니다.
+                        console.log(error.request);
+                    }
+                    else {
+                        // 오류를 발생시킨 요청을 설정하는 중에 문제가 발생했습니다.
+                        console.log('Error', error.message);
+                    }
 
-                _equipment.description = _row.deviceDescription
+                    reject(error.message)
+                })
 
-                _equipment.endRentalDate = _row.endRentalDate
-                _equipment.rentalUser = _row.rentalUser
-
-                // _equipment.description = _row.deviceDescription // 비고
-                _equipment.user = _row.rentalUser // 대여자 이름
-                _equipment.date = _row.endRentalDate // 반납예정일
-                _equipment.status = _row.rentalStatus // 대여상태 [신청 완료(0) / 대여중(1) / 연체(2) / 반납완료(3) ]
-                _equipment.isRented = _row.rentalId && _row.rentalId > 0 ? true : false // 대여여부
-
-                var _copied = Object.assign({}, _equipment)
-
-                _equipmentList.push(_copied) 
-            }
-
-            commit("updateEquipmentList", _equipmentList)
-        },
-
-        async searchEquipment({ state, commit }, payload){
-            const res = payload.keyword
-            commit('updateState',{
-                keyword : res
             })
-            console.log(state.keyword,'스토어')
+            
         },
+
+        // API - 대여신청
+        async EQUIPMENT_RENTAL_REQUEST({ commit }, payload) {
+            console.log('equipments.js actions EQUIPMENT_RENTAL_REQUEST')
+            return new Promise((resolve, reject) => {
+                api.requestEquipmentRental(payload)
+                .then(response => {
+                    console.log('actions EQUIPMENT_RENTAL_REQUEST response', response)
+                    if (response.isSuccessful) {
+                        console.log('actions EQUIPMENT_RENTAL_REQUEST true')
+                        commit('EQUIPMENT_RENTAL_REQUEST_SUCCESS')
+                        resolve(response.data)
+                    } else {
+                        console.log('actions EQUIPMENT_RENTAL_REQUEST false')
+                        commit('EQUIPMENT_RENTAL_REQUEST_FAIL')
+                        reject(response.error)
+                    }
+                }).catch(error => {
+
+                    console.log('catch error', error);
+
+                    if (error.response) {
+                        // 요청이 이루어졌으며 서버가 2xx의 범위를 벗어나는 상태 코드로 응답했습니다.
+                        console.log(error.response.data);
+                        console.log(error.response.status);
+                        console.log(error.response.headers);
+                    }
+                    else if (error.request) {
+                        // 요청이 이루어 졌으나 응답을 받지 못했습니다.
+                        // `error.request`는 브라우저의 XMLHttpRequest 인스턴스 또는
+                        // Node.js의 http.ClientRequest 인스턴스입니다.
+                        console.log(error.request);
+                    }
+                    else {
+                        // 오류를 발생시킨 요청을 설정하는 중에 문제가 발생했습니다.
+                        console.log('Error', error.message);
+                    }
+
+                    // console.log(error.config);
+
+                    console.log('actions EQUIPMENT_RENTAL_REQUEST catch error', error.response)
+
+                    // alert('TODO 예외 발생')
+                    reject(error.message)
+                })
+            })
+        },
+
+        // 일반사용자 > 대시보드 > 앱바 > 내 정보 : 신청 내역 조회
+        async EQUIPMENT_RENTAL_HISTORY({ commit }, payload) {
+            console.log('EQUIPMENT_RENTAL_HISTORY')
+            return new Promise((resolve, reject) => {
+                api.getRentalHistory(payload)
+                .then(response => {
+                    console.log('actions EQUIPMENT_RENTAL_HISTORY response', response)
+                    if (response.isSuccessful) {
+                        console.log('actions EQUIPMENT_RENTAL_HISTORY true')
+
+                        var list = response && response.data ? response.data : []
+
+                        var _rentalHistoryList = []
+                        var _rentalHistory = { 
+                            id: '', 
+                            name: '', // 기기명
+                            manufacturer: '', // 제조사
+                            os: '', // OS
+                            type: '', // 장비종류
+                            modelNumber: '', // 모델 번호
+                            serialNumber: '', // 시리얼 번호
+                            purchaseDate: '', // 구입일(인수일)
+                            description: '', // 비고 : 구입일 모름(인수일 기재) 본사에서 구입(라디오)
+                            user: '',
+                            date: '',
+                            isSelected: false, 
+                            isRented: false,
+                            endRentalDate: '',
+                            rentalUser: ''
+                        }
+
+                        // for (var key in list) {
+                        //     var _row = []
+                        //     _row = list[key]
+            
+                        //     _equipment.id = _row.deviceId // 기기 ID
+                        //     _equipment.model = _row.deviceName // 기기명
+                        //     _equipment.os = _row.deviceOsName // OS
+                        //     _equipment.type = _row.deviceType
+                        //     _equipment.manufacturer = _row.deviceManufacturer
+                        //     _equipment.serialNumber = _row.deviceSerialNumber
+                        //     _equipment.modelNumber = _row.deviceModelNumber
+            
+                        //     _equipment.purchaseDate = _row.devicePurchaseDate
+            
+                        //     _equipment.description = _row.deviceDescription
+            
+                        //     _equipment.endRentalDate = _row.endRentalDate
+                        //     _equipment.rentalUser = _row.rentalUser
+            
+                        //     // _equipment.description = _row.deviceDescription // 비고
+                        //     _equipment.user = _row.rentalUser // 대여자 이름
+                        //     _equipment.date = _row.endRentalDate // 반납예정일
+                        //     _equipment.status = _row.rentalStatus // 대여상태 [신청 완료(0) / 대여중(1) / 연체(2) / 반납완료(3) ]
+                        //     _equipment.isRented = _row.rentalId && _row.rentalId > 0 ? true : false // 대여여부
+            
+                        //     var _copied = Object.assign({}, _equipment)
+            
+                        //     _equipmentList.push(_copied) 
+                        // }
+
+                        commit('EQUIPMENT_RENTAL_HISTORY_SUCCESS', response.data)
+                        resolve(response.data)
+                    } else {
+                        console.log('actions EQUIPMENT_RENTAL_HISTORY false')
+                        commit('EQUIPMENT_RENTAL_HISTORY_FAIL')
+                        reject(response.error)
+                    }
+                }).catch(error => {
+
+                    console.log('catch error', error);
+
+                    if (error.response) {
+                        // 요청이 이루어졌으며 서버가 2xx의 범위를 벗어나는 상태 코드로 응답했습니다.
+                        console.log(error.response.data);
+                        console.log(error.response.status);
+                        console.log(error.response.headers);
+                    }
+                    else if (error.request) {
+                        // 요청이 이루어 졌으나 응답을 받지 못했습니다.
+                        // `error.request`는 브라우저의 XMLHttpRequest 인스턴스 또는
+                        // Node.js의 http.ClientRequest 인스턴스입니다.
+                        console.log(error.request);
+                    }
+                    else {
+                        // 오류를 발생시킨 요청을 설정하는 중에 문제가 발생했습니다.
+                        console.log('Error', error.message);
+                    }
+
+                    // console.log(error.config);
+
+                    console.log('actions EQUIPMENT_RENTAL_HISTORY catch error', error.response)
+
+                    // alert('TODO 예외 발생')
+                    reject(error.message)
+                })
+            })
+        },
+
         rejectEquipment({ state, commit }, payload){}
     }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,9 +2,14 @@ import { createStore } from 'vuex'
 import equipments from './equipments'
 import members from './members'
 
+import createPersistedState from 'vuex-persistedstate'
+
 export default createStore({
     modules:{
         equipments,
         members
-    }
+    },
+    plugins: [
+        createPersistedState()
+    ]
 })

--- a/src/store/members.js
+++ b/src/store/members.js
@@ -1,40 +1,103 @@
 import { api } from '~/api/api'
-import VueCookies from 'vue-cookies'
+// import VueCookies from 'vue-cookies'
 
 const _defaultMsg = "완료되었습니다."
 
 export default{
     namespaced:true,
     state:()=>({
-        succesedMsg:_defaultMsg
+        succesedMsg:_defaultMsg,
+        loggedIn: false,
+        administrator: false,
+        user: {
+            name: ''
+        }
     }),
-    getters:{},
+    getters:{
+        // parseJwt: function(token) {
+        //     console.log('[common.js][parseJwt]', token)
+        //     var base64Url = token.split('.')[1]
+        //     var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+        //     var jsonPayload = decodeURIComponent(window.atob(base64).split('').map(function(c) {
+        //         return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+        //     }).join(''))
+    
+        //     return JSON.parse(jsonPayload)
+        // }
+    },
     mutations:{
 
-        LOGIN_SUCCESS (state, payload) {
+        LOGIN_SUCCESS(state, payload) {
             console.log('members.js > mutations > LOGIN_SUCCESS', 'state', state, 'payload', payload)
-    
-            VueCookies.set('accessToken', payload.access_token, '1d')
+
+            localStorage.setItem('access_token', payload.access_token)
+
+            // VueCookies.set('accessToken', payload.access_token, '1d')
             // VueCookies.set('refreshToken', payload.refreshToken, '1h')
-    
+
             // 스토어에 액세스 토큰 저장
-            state.accessToken = payload.access_token
+            // state.accessToken = payload.access_token
             // state.refreshToken = payload.refreshToken
-    
+
             // 모든 HTTP 요청 헤더에 Authorization 을 추가한다.
             // service.defaults.headers.common['Authorization'] = `Bearer ${payload.accessToken}`;
-          },
-          refreshToken(state, payload) { //accessToken 재셋팅
-            console.log('mutations.js refreshToken', 'state', state, 'payload', payload)
-            VueCookies.set('accessToken', payload.accessToken, '60s')
-            VueCookies.set('refreshToken', payload.refreshToken, '1h')
-            state.accessToken = payload;
-          },
-          removeToken () {
-            console.log('mutations.js removeToken')
-            VueCookies.remove('accessToken')
-            VueCookies.remove('refreshToken')
-          },
+
+            var base64Url = payload.access_token.split('.')[1]
+            var base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+            var jsonPayload = decodeURIComponent(window.atob(base64).split('').map(function(c) {
+                return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)
+            }).join(''))
+            var result = JSON.parse(jsonPayload)
+
+            state.loggedIn = true
+
+            if (result) {
+                console.log('LOGIN_SUCCESS result', result)
+                if (result.authorities) {
+                    result.authorities.forEach((authentication) => {
+                        console.log('authentication', authentication)
+                        console.log('authentication.authority', authentication.authority)
+                        if (authentication.authority == 'ROLE_MASTER') {
+                            console.log('ROLE_MASTER')
+                            state.administrator = true
+                        }
+                    })
+                }
+            }
+
+            state.loggedIn = true
+            state.user.name = result.name
+
+            console.log('LOGIN_SUCCESS state.user.name', state.user.name)
+        },
+
+        LOGIN_FAIL(state, payload) {
+            console.log('members.js > mutations > LOGIN_FAIL', 'state', state, 'payload', payload)
+            state.loggedIn = false
+            state.administrator = false
+            state.user.name = ''
+        },
+
+        TOKEN_REFRESH(state, payload) { //accessToken 재셋팅
+            console.log('mutations.js TOKEN_REFRESH', 'state', state, 'payload', payload)
+            // VueCookies.set('accessToken', payload.accessToken, '60s')
+            // VueCookies.set('refreshToken', payload.refreshToken, '1h')
+
+            localStorage.setItem('access_token', payload.access_token)
+            state.accessToken = payload
+        },
+
+        TOKEN_REMOVE(state) {
+            console.log('mutations.js TOKEN_REMOVE')
+            // VueCookies.remove('accessToken')
+            // VueCookies.remove('refreshToken')
+
+            localStorage.removeItem('access_token')
+
+            state.loggedIn = false
+            state.administrator = false
+            state.user.name = ''
+        },
 
     },
     actions:{
@@ -45,27 +108,32 @@ export default{
             return new Promise((resolve, reject) => {
               api.signIn(params).then(response => {
                 console.log('actions login response', response)
-                if (response && response.status == 200) {
-                    if (response.data) {
-                        if (response.data.access_token) {
-                          // LOGIN 변이 실행
-                          commit('LOGIN_SUCCESS', response.data)
-                          resolve(response.data)
-                        } 
+                if (response) {
+                    if (response.isSuccessful) { // LOGIN 변이 실행
+                        console.log('actions login if')
+                        commit('LOGIN_SUCCESS', response.data)
+                        resolve(response.data)
+                    } else {
+                        console.log('actions login else')
+                        commit('LOGIN_FAIL')
+                        reject(response.error)
                     }
+                } else {
+                    console.log('Internal Server Error')
+                    commit('LOGIN_FAIL')
+                    reject()
                 }
             }).catch(error => {
                     console.log('actions login catch error', error)
-                    alert('TODO 예외 발생')
-                    reject(error.message)
+                    commit('LOGIN_FAIL')
+                    reject(error)
                 })
             })
         },
 
         LOGOUT: ({commit}) => { // 로그아웃
             console.log('members.js > actions > LOGOUT', commit)
-            commit('logout')
-            location.reload()
+            commit('TOKEN_REMOVE')
         }
 
     }

--- a/src/store/members.js
+++ b/src/store/members.js
@@ -1,3 +1,6 @@
+import { api } from '~/api/api'
+import VueCookies from 'vue-cookies'
+
 const _defaultMsg = "완료되었습니다."
 
 export default{
@@ -6,6 +9,64 @@ export default{
         succesedMsg:_defaultMsg
     }),
     getters:{},
-    mutations:{},
-    actions:{}
+    mutations:{
+
+        LOGIN_SUCCESS (state, payload) {
+            console.log('members.js > mutations > LOGIN_SUCCESS', 'state', state, 'payload', payload)
+    
+            VueCookies.set('accessToken', payload.access_token, '1d')
+            // VueCookies.set('refreshToken', payload.refreshToken, '1h')
+    
+            // 스토어에 액세스 토큰 저장
+            state.accessToken = payload.access_token
+            // state.refreshToken = payload.refreshToken
+    
+            // 모든 HTTP 요청 헤더에 Authorization 을 추가한다.
+            // service.defaults.headers.common['Authorization'] = `Bearer ${payload.accessToken}`;
+          },
+          refreshToken(state, payload) { //accessToken 재셋팅
+            console.log('mutations.js refreshToken', 'state', state, 'payload', payload)
+            VueCookies.set('accessToken', payload.accessToken, '60s')
+            VueCookies.set('refreshToken', payload.refreshToken, '1h')
+            state.accessToken = payload;
+          },
+          removeToken () {
+            console.log('mutations.js removeToken')
+            VueCookies.remove('accessToken')
+            VueCookies.remove('refreshToken')
+          },
+
+    },
+    actions:{
+
+        LOGIN: ({commit}, params) => {
+            console.log('members.js > actions > LOGIN', params)
+    
+            return new Promise((resolve, reject) => {
+              api.signIn(params).then(response => {
+                console.log('actions login response', response)
+                if (response && response.status == 200) {
+                    if (response.data) {
+                        if (response.data.access_token) {
+                          // LOGIN 변이 실행
+                          commit('LOGIN_SUCCESS', response.data)
+                          resolve(response.data)
+                        } 
+                    }
+                }
+            }).catch(error => {
+                    console.log('actions login catch error', error)
+                    alert('TODO 예외 발생')
+                    reject(error.message)
+                })
+            })
+        },
+
+        LOGOUT: ({commit}) => { // 로그아웃
+            console.log('members.js > actions > LOGOUT', commit)
+            commit('logout')
+            location.reload()
+        }
+
+    }
 }


### PR DESCRIPTION
안녕하세요. 

일반 사용자 FE/BE 연동 작업 후 소스 Push 하려고 보니 Push 권한이 없어 프로젝트 fork 후 Pull Request 요청 드립니다.

작업 내용 반영 과정에서 Conflict 나는 부분이 있거나 FE 개발 관점에서 작업 내용에 수정이 필요한 부분이 있다면 코멘트 부탁 드리며, 없다면 Merge 부탁 드립니다.

고맙습니다. :)   

## 요약
- KBS미디어 8층 디지털사업부 부서 장비 시스템 FE 소스와 BE 소스 연동하여 실제 기능 구현 완성
- local에서 작업 내용 확인 시 src/api/service.js 에서 baseURL local -> mockup 변경 후 확인

## 상세
1. **FE/BE 연동을 위한 사전 작업**
    1) common
        - 로그인 전후 페이지 이동 처리 관련 토큰 디코딩, 날짜 변환 함수 추가 (common.js 파일 추가)
    2) axios
        - HTTP 통신 라이브러리(=axios) 설정 및 응답처리 공통 객체 설정
        - API 정의 및 동작 관련 파일 추가 (api.js, config.js, service.js)
            - 회원가입/로그인 관련 API 목록 작성
                - 회원가입 API
                - 로그인 API
            - 대시보드 메인 화면 API 목록 작성
                - 장비목록 조회 API
                - 장비대여 신청 API
                - 신청목록 조회 API
    3) vuex-persistedstate
        - 화면 새로고침 시 vuex state 초기화 방지 라이브러리 추가 및 적용 (vuex-persistedstate)
            - vuex-persistedstate가 vuex state에 저장된 변수와 값을 그대로 웹브라우저의 localStorage에 업데이트 함
            - vuex state와 localstorage 데이터 동기화
        - vue-cookie 사용코드 주석처리
            - jwt cookie -> localStorage에 저장하는 형태로 변경
    4) 내비게이션 가드
        - 라우팅 담당 index.js 파일에 beforeEnter 속성 추가 및 requireAuth 함수 추가
        - 라우팅 목록에 대여신청 완료 시 이동 화면 추가 및 route 화면 파일 생성 (RentRequestDone.vue)

2. **로그인 화면 연동**
    1) FormSignIn.vue 컴포넌트에 로그인 API 연동 관련 로직 추가
    2) 로그인 API 로직 처리를 수행하는 store/members.js 파일에 actions, mutations 관련 코드 추가
    3) 로그인 시 Header 유저 정보 및 관리자 메뉴 동적 노출 로직 추가
        - 로그인 시 모든 유저 Header에 유저 정보 노출되도록 코드 작성 (state 값 사용)
        - 로그인 시 관리자인 경우 Header에 관리자 메뉴 노출되도록 코드 작성 (state 값 사용)
    4) 로그인 시 localStorage access_token 등록
    5) 로그아웃 시 localStorage access_token 삭제

3. **회원가입 화면 연동**
    1) FormSignUp.vue 컴포넌트에 회원가입 API 연동 관련 로직 추가
    2) 회원가입 API 로직 처리를 수행하는 members.js 파일에 actions, mutations 관련 코드 추가
    3) 회원가입 시 클라이언트 사이드 데이터 유효성 검증 로직 추가

4. **대시보드 메인 화면 연동**
    1) 장비 목록 조회 (API)
        - 관련 컴포넌트에 대시보드 장비 목록 조회 API 연동 관련 로직 추가
            - MainTabs.vue
            - Search.vue
        - 대시보드 장비 목록 조회 API 로직 처리를 수행하는 equipments.js 파일에 actions, mutations 관련 코드 추가
    2) 장비 상세 조회 (NOT API)
        - 관련 컴포넌트 간 데이터 전달 로직 추가 및 이벤트 연동
            - CardItem.vue
            - MainCardList.vue
            - DetailModal.vue
        - Props 데이터 바인딩
        - 신청하기 버튼 클릭 시 동작 함수 연결 (추가 작업 필요)
    3) 장비 대여 (API)
        - 관련 컴포넌트에 대시보드 장비 대여 API 연동 관련 로직 추가
            - ApplyCardList.vue
            - Collapse.vue
            - DatePicker.vue
            - CancelModal.vue
        - 장비 대여 API 로직 처리를 수행하는 equipments.js 파일에 actions, mutations 관련 코드 추가
    4) 신청내역 조회 (API)
        - 관련 컴포넌트에 대시보드 장비 대여 API 연동 관련 로직 추가
            - BasicTable.vue
            - MyApplyList.vue
            - MyPage.vue
        - 신청내역 조회 API 로직 처리를 수행하는 equipments.js 파일에 actions, mutations 관련 코드 추가